### PR TITLE
First pass at updating docs for redhat-cop refs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This catalog is not officially supported by Red Hat and customers are discourage
 Each catalog item has (or will have) its own README in its directory root with instructions.  Generally speaking, you can usually just apply a "base" or "overlay" directly in your cluster by cloning this repostitory and using the `-k` flag (for Kustomize) built into `oc` and `kubectl`:
 
 ```
-git clone https://github.com/redhat-canada-gitops
+git clone https://github.com/redhat-cop/gitops-catalog
 oc apply -k catalog/jenkins2/overlays/default
 ```
 
 Or to skip the cloning step:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/jenkins2/overlays/default
+oc apply -k https://github.com/redhat-cop/gitops-catalog/jenkins2/overlays/default
 ```
 
 ## Kustomize
@@ -30,7 +30,7 @@ kind: Kustomization
 namespace: product-catalog-cicd
 
 resources:
-- github.com/redhat-canada-gitops/catalog/jenkins2/bases/?ref=master
+- github.com/redhat-cop/gitops-catalog/jenkins2/bases/?ref=master
 ```
 
 This enables you to patch these resources for your specific environments. Note that none of these bases specify a namespace, in your kustomization

--- a/amq-streams-operator/README.md
+++ b/amq-streams-operator/README.md
@@ -10,7 +10,7 @@ Current channel overlays include:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the AMQ Streams operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the AMQ Streams operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k amq-streams-operator/overlays/<channel>
@@ -19,7 +19,7 @@ oc apply -k amq-streams-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/amq-streams-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/amq-streams-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -29,5 +29,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/amq-streams-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/amq-streams-operator/overlays/<channel>?ref=main
 ```

--- a/elastisearch-operator/README.md
+++ b/elastisearch-operator/README.md
@@ -11,7 +11,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Elastisearch operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Elastisearch operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k elastisearch-operator/overlays/<channel>
@@ -20,7 +20,7 @@ oc apply -k elastisearch-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/elastisearch-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/elastisearch-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -30,5 +30,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/elastisearch-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/elastisearch-operator/overlays/<channel>?ref=main
 ```

--- a/installplan-approver/README.md
+++ b/installplan-approver/README.md
@@ -4,7 +4,7 @@ In OCP 4 when you set an operator for manual upgrades you need to manually appro
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the installplan-approver job based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the installplan-approver job based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k installplan-approval/base
@@ -13,7 +13,7 @@ oc apply -k installplan-approval/base
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/installplan-approval/base
+oc apply -k https://github.com/redhat-cop/gitops-catalog/installplan-approval/base
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -23,5 +23,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/installplan-approval/base?ref=master
+  - github.com/redhat-cop/gitops-catalog/installplan-approval/base?ref=main
 ```

--- a/jaeger-operator/overlays/README.md
+++ b/jaeger-operator/overlays/README.md
@@ -10,7 +10,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Jaeger operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Jaeger operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k jaeger-operator/overlays/<channel>
@@ -19,7 +19,7 @@ oc apply -k jaeger-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/jaeger-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/jaeger-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -29,5 +29,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/jaeger-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/jaeger-operator/overlays/<channel>?ref=main
 ```

--- a/kiali-operator/README.md
+++ b/kiali-operator/README.md
@@ -9,7 +9,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Pipelines operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Pipelines operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k kiali-operator/overlays/<channel>
@@ -18,7 +18,7 @@ oc apply -k kiali-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/kiali-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/kiali-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -28,5 +28,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/kiali-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/kiali-operator/overlays/<channel>?ref=main
 ```

--- a/letsencrypt-certs/README.md
+++ b/letsencrypt-certs/README.md
@@ -12,7 +12,7 @@ This currently is AWS-only, however, it should be relatively easy to expand to A
 
 This job requires an AWS IAM user with Route53 access.  It expects these credentials in the form of two environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 
-This `Job` will inject these values from a `Secret` with the name `cloud-dns-credentials` and keys of the same names.  However, since it's a really bad idea to put a plain k8s `Secret` in a git repository, you will want to use [Sealed Secrets](https://github.com/redhat-canada-gitops/catalog/tree/master/sealed-secrets-operator);
+This `Job` will inject these values from a `Secret` with the name `cloud-dns-credentials` and keys of the same names.  However, since it's a really bad idea to put a plain k8s `Secret` in a git repository, you will want to use [Sealed Secrets](https://github.com/redhat-cop/gitops-catalog/tree/main/sealed-secrets-operator);
 
 ## Environment Variables
 

--- a/namespace-configuration-operator/README.md
+++ b/namespace-configuration-operator/README.md
@@ -1,5 +1,5 @@
 # Namespace Configuration Operator
 
-This installs the namespace-configuration-operator which provides addtional features and capabilities for driving self-service out of OpenShift. Additional information about this operator can be found in the [namespace-configuration-operator](https://github.com/redhat-cop/namespace-configuration-operator) repo.
+This installs the namespace-configuration-operator which provides addtional features and capabilities for driving self-service out of OpenShift. Additional information about this operator can be found in the [namespace-configuration-operator](https://github.com/redhat-cop/gitops-catalog/namespace-configuration-operator) repo.
 
-Examples on how to use this operator can be viewed [here](https://github.com/redhat-cop/namespace-configuration-operator/tree/master/examples).
+Examples on how to use this operator can be viewed [here](https://github.com/redhat-cop/gitops-catalog/namespace-configuration-operator/tree/main/examples).

--- a/opendatahub-operator/README.md
+++ b/opendatahub-operator/README.md
@@ -9,7 +9,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Pipelines operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Pipelines operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k opendatahub-operator/overlays/<channel>
@@ -18,7 +18,7 @@ oc apply -k opendatahub-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/opendatahub-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/opendatahub-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -28,5 +28,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/opendatahub-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/opendatahub-operator/overlays/<channel>?ref=main
 ```

--- a/openshift-container-storage-noobaa/README.md
+++ b/openshift-container-storage-noobaa/README.md
@@ -19,7 +19,7 @@ The current *overlays* available are:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install Noobaa by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install Noobaa by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-container-storage-noobaa/overlays/default
@@ -28,7 +28,7 @@ oc apply -k openshift-container-storage-noobaa/overlays/default
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-container-storage-noobaa/overlays/default
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-container-storage-noobaa/overlays/default
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -38,5 +38,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-container-storage-noobaa/overlays/default?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-container-storage-noobaa/overlays/default?ref=main
 ```

--- a/openshift-container-storage-operator/README.md
+++ b/openshift-container-storage-operator/README.md
@@ -10,7 +10,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Container Storage operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Container Storage operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-container-storage-operator/overlays/<channel>
@@ -19,7 +19,7 @@ oc apply -k openshift-container-storage-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-container-storage-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-container-storage-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -29,5 +29,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-container-storage-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-container-storage-operator/overlays/<channel>?ref=main
 ```

--- a/openshift-gitops-operator/README.md
+++ b/openshift-gitops-operator/README.md
@@ -11,7 +11,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift GitOps operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift GitOps operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-gitops-operator/overlays/<channel>
@@ -20,5 +20,5 @@ oc apply -k openshift-gitops-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-gitops-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-gitops-operator/overlays/<channel>
 ```

--- a/openshift-pipelines-operator/README.md
+++ b/openshift-pipelines-operator/README.md
@@ -11,7 +11,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Pipelines operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Pipelines operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-pipelines-operator/overlays/<channel>
@@ -20,7 +20,7 @@ oc apply -k openshift-pipelines-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-pipelines-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-pipelines-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -30,5 +30,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-pipelines-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-pipelines-operator/overlays/<channel>?ref=main
 ```

--- a/openshift-pipelines-tasks/dotnet/README.md
+++ b/openshift-pipelines-tasks/dotnet/README.md
@@ -22,4 +22,4 @@ Sample task usage:
 
 **Note:** the `--source` parameter in the example is just one way to use your own artifact repository for NuGet, provided it has been properly configured as a NuGet proxy.
 
-The [Nexus 2](https://github.com/redhat-canada-gitops/catalog/tree/master/nexus2/base) instance is configured by default (through a Job that runs after Nexus is running) as a NuGet proxy.
+The [Nexus 2](https://github.com/redhat-cop/gitops-catalog/tree/master/nexus2/base) instance is configured by default (through a Job that runs after Nexus is running) as a NuGet proxy.

--- a/openshift-serverless-knative-eventing/README.md
+++ b/openshift-serverless-knative-eventing/README.md
@@ -14,7 +14,7 @@ The current *overlays* available are:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install Noobaa by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install Noobaa by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-serverless-knative-eventing/overlays/default
@@ -23,7 +23,7 @@ oc apply -k openshift-serverless-knative-eventing/overlays/default
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-serverless-knative-eventing/overlays/default
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-serverless-knative-eventing/overlays/default
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -33,5 +33,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-serverless-knative-eventing/overlays/default?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-serverless-knative-eventing/overlays/default?ref=main
 ```

--- a/openshift-serverless-knative-serving/README.md
+++ b/openshift-serverless-knative-serving/README.md
@@ -13,7 +13,7 @@ The current *overlays* available are:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install Noobaa by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install Noobaa by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-serverless-knative-serving/overlays/default
@@ -22,7 +22,7 @@ oc apply -k openshift-serverless-knative-serving/overlays/default
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-serverless-knative-serving/overlays/default
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-serverless-knative-serving/overlays/default
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -32,5 +32,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-serverless-knative-serving/overlays/default?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-serverless-knative-serving/overlays/default?ref=main
 ```

--- a/openshift-serverless-operator/README.md
+++ b/openshift-serverless-operator/README.md
@@ -11,7 +11,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Serverless operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Serverless operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-serverless-operator/overlays/<channel>
@@ -20,7 +20,7 @@ oc apply -k openshift-serverless-operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-serverless-operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-serverless-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -30,5 +30,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-serverless-operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-serverless-operator/overlays/<channel>?ref=main
 ```

--- a/openshift-servicemesh/instance/README.md
+++ b/openshift-servicemesh/instance/README.md
@@ -20,7 +20,7 @@ The current *overlays* available are:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install Noobaa by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install Noobaa by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-servicemesh/instance/overlays/default
@@ -29,7 +29,7 @@ oc apply -k openshift-servicemesh/instance/overlays/default
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-servicemesh/instance/overlays/default
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-servicemesh/instance/overlays/default
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -39,5 +39,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-servicemesh/instance/overlays/default?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-servicemesh/instance/overlays/default?ref=main
 ```

--- a/openshift-servicemesh/operator/README.md
+++ b/openshift-servicemesh/operator/README.md
@@ -10,7 +10,7 @@ The current *overlays* available are for the following channels:
 
 ## Usage
 
-If you have cloned the `catalog` repository, you can install the OpenShift Service Mesh operator based on the overlay of your choice by running from the root `catalog` directory
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Service Mesh operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
 oc apply -k openshift-servicemesh/operator/overlays/<channel>
@@ -19,7 +19,7 @@ oc apply -k openshift-servicemesh/operator/overlays/<channel>
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-canada-gitops/catalog/openshift-servicemesh/operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-servicemesh/operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -29,5 +29,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - github.com/redhat-canada-gitops/catalog/openshift-servicemesh/operator/overlays/<channel>?ref=master
+  - github.com/redhat-cop/gitops-catalog/openshift-servicemesh/operator/overlays/<channel>?ref=main
 ```


### PR DESCRIPTION
First pass at updating docs to reference `redhat-cop/gitops-catalg` instead of `redhat-canada-gitops/catalog`.