### PR TITLE
Kustomize build test

### DIFF
--- a/.github/workflows/kustomize-check.yml
+++ b/.github/workflows/kustomize-check.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  lint-kustomize:
+  kustomize-build-check:
     runs-on: ubuntu-latest
     container:
       # Use the same version of kustomize available with Argo

--- a/.github/workflows/kustomize-check.yml
+++ b/.github/workflows/kustomize-check.yml
@@ -25,7 +25,7 @@ jobs:
           kustomize version
           echo ""
 
-          find -type f -name "kustomization.yaml" | while read file
+          find -type f -iname "kustomization.y*ml" | while read file
           do
               dir=$(dirname "$file")
               echo "Testing ${dir}"

--- a/.github/workflows/kustomize-check.yml
+++ b/.github/workflows/kustomize-check.yml
@@ -1,0 +1,29 @@
+name: Kustomize Check
+
+on: 
+  push: {}
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-kustomize:
+    runs-on: ubuntu-latest
+    container:
+      # Use the same version of kustomize available with Argo
+      image: zillownyc/kustomize:3.5.4
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Validate all kustomization.yaml files
+        run: |
+          #!/bin/bash
+          set -e
+          find -type f -name "kustomization.yaml" | while read file
+          do
+              dir=$(dirname "$file")
+              echo "Testing ${dir}"
+              kustomize build "${dir}"
+              echo "---------------------------"
+          done

--- a/.github/workflows/kustomize-check.yml
+++ b/.github/workflows/kustomize-check.yml
@@ -23,6 +23,7 @@ jobs:
 
           echo "Kustomize Version:"
           kustomize version
+          echo ""
 
           find -type f -name "kustomization.yaml" | while read file
           do

--- a/.github/workflows/kustomize-check.yml
+++ b/.github/workflows/kustomize-check.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           #!/bin/bash
           set -e
+
+          echo "Kustomize Version:"
+          kustomize version
+
           find -type f -name "kustomization.yaml" | while read file
           do
               dir=$(dirname "$file")

--- a/.github/workflows/kustomize-check.yml
+++ b/.github/workflows/kustomize-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Use the same version of kustomize available with Argo
-      image: zillownyc/kustomize:3.5.4
+      image: nekottyo/kustomize-kubeval:kustomizev4
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2

--- a/.github/workflows/kustomize-check.yml
+++ b/.github/workflows/kustomize-check.yml
@@ -1,10 +1,6 @@
 name: Kustomize Check
 
-on: 
-  push: {}
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   kustomize-build-check:

--- a/compliance-operator/overlays/release-0.1/kustomization.yaml
+++ b/compliance-operator/overlays/release-0.1/kustomization.yaml
@@ -14,4 +14,5 @@ patchesJson6902:
       group: operators.coreos.com
       kind: Subscription
       name: compliance-operator
+      namespace: openshift-operators
       version: v1alpha1

--- a/grafana-operator/overlays/user-app/kustomization.yaml
+++ b/grafana-operator/overlays/user-app/kustomization.yaml
@@ -5,8 +5,8 @@ commonAnnotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 bases:
-- github.com/redhat-canada-gitops/catalog/grafana-operator/base/operator
-- github.com/redhat-canada-gitops/catalog/grafana-operator/base/instance
+- github.com/redhat-cop/gitops-catalog/grafana-operator/base/operator
+- github.com/redhat-cop/gitops-catalog/grafana-operator/base/instance
 
 resources:
 - grafana-ds.yaml

--- a/grafana-operator/overlays/user-app/kustomization.yaml
+++ b/grafana-operator/overlays/user-app/kustomization.yaml
@@ -5,8 +5,8 @@ commonAnnotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 bases:
-- github.com/redhat-canada-gitops/catalog//grafana-operator/base/operator
-- github.com/redhat-canada-gitops/catalog//grafana-operator/base/instance
+- github.com/redhat-canada-gitops/catalog/grafana-operator/base/operator
+- github.com/redhat-canada-gitops/catalog/grafana-operator/base/instance
 
 resources:
 - grafana-ds.yaml

--- a/rhsso/rhsso-instance/overlays/crc/kustomization.yaml
+++ b/rhsso/rhsso-instance/overlays/crc/kustomization.yaml
@@ -2,8 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
+<<<<<<< HEAD
   - ../../base/sso
   - ../../base/openshift-authentication
+=======
+  - ../../base
+>>>>>>> f426413... fix base ref issue
 
 resources:
   - oauth-rhsso-openid.yaml

--- a/rhsso/rhsso-instance/overlays/crc/kustomization.yaml
+++ b/rhsso/rhsso-instance/overlays/crc/kustomization.yaml
@@ -2,12 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-<<<<<<< HEAD
-  - ../../base/sso
-  - ../../base/openshift-authentication
-=======
   - ../../base
->>>>>>> f426413... fix base ref issue
 
 resources:
   - oauth-rhsso-openid.yaml

--- a/rhsso/rhsso-instance/overlays/rhpds/kustomization.yaml
+++ b/rhsso/rhsso-instance/overlays/rhpds/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - ../../base/sso
+  - ../../base
 
 resources:
   - oauth-rhsso-openid.yaml

--- a/selenium/base/selenium-node-firefox-debug-bc.yaml
+++ b/selenium/base/selenium-node-firefox-debug-bc.yaml
@@ -5,6 +5,7 @@ metadata:
     app: selenium
     build: selenium-node-firefox-debug
     type: image
+  name: selenium-node-firefox-debug
 spec:
   failedBuildsHistoryLimit: 5
   nodeSelector: {}


### PR DESCRIPTION
Add a github action to run a `kustomize build` on any kustomization.yaml or kustomization.yml files in the repo.

The image being used to test leverages kustomize 4.2 which should match the current version of Argo.

This also resolves several existing issues in the repo for items that do not properly build.

Moving forward this will help to insure that all PR's can successfully build.