### PR TITLE
Change default image to a RH image

### DIFF
--- a/openshift-pipelines-tasks/maven/base/maven-task.yaml
+++ b/openshift-pipelines-tasks/maven/base/maven-task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   description: This Task can be used to run a Maven build.  Based on the maven ClusterTask.
   params:
-    - default: gcr.io/cloud-builders/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641
+    - default: image-registry.openshift-image-registry.svc:5000/openshift/java:openjdk-11-ubi8
       # Can't use registry.access.redhat.com/ubi8/openjdk-11 due to https://issues.redhat.com/browse/SRVKP-1428
       description: Maven base image
       name: MAVEN_IMAGE


### PR DESCRIPTION
Change the maven's default task from a google image to a Red Hat one that is included in OpenShift