### PR TITLE
Fix for issue 54.

### DIFF
--- a/elastisearch-operator/base/elasticsearch-operatorgroup.yaml
+++ b/elastisearch-operator/base/elasticsearch-operatorgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-operators-redhat
+  namespace: openshift-operators-redhat
+spec: {}

--- a/elastisearch-operator/base/elastisearch-subscription.yaml
+++ b/elastisearch-operator/base/elastisearch-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: "4.5"
+  channel: "patch-me-in-overlay"
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: redhat-operators

--- a/elastisearch-operator/base/kustomization.yaml
+++ b/elastisearch-operator/base/kustomization.yaml
@@ -4,4 +4,6 @@ kind: Kustomization
 namespace: openshift-operators-redhat
 
 resources:
-- elastisearch-subscription.yaml
+  - namespace.yaml
+  - elastisearch-subscription.yaml
+  - elasticsearch-operatorgroup.yaml

--- a/elastisearch-operator/base/namespace.yaml
+++ b/elastisearch-operator/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat


### PR DESCRIPTION
Fix for https://github.com/redhat-cop/gitops-catalog/issues/54 .  Added `openshift-operators-redhat` namespace and updated base/overlays where required.