### PR TITLE
Update Nexus and Sonarqube script URLs

### DIFF
--- a/nexus2/base/configure-nexus-job.yaml
+++ b/nexus2/base/configure-nexus-job.yaml
@@ -17,7 +17,7 @@ spec:
 
               echo "Nexus is up!  Configure repository proxies."
 
-              curl -o /tmp/nexus-functions -s https://raw.githubusercontent.com/redhat-canada-gitops/catalog/master/nexus2/scripts/nexus-functions;
+              curl -o /tmp/nexus-functions -s https://raw.githubusercontent.com/redhat-cop/gitops-catalog/main/nexus2/scripts/nexus-functions;
 
               source /tmp/nexus-functions; add_nexus2_redhat_repos admin admin123 http://nexus:8081
           imagePullPolicy: Always

--- a/sonarqube8/overlays/plugins/configure-sonarqube-job.yaml
+++ b/sonarqube8/overlays/plugins/configure-sonarqube-job.yaml
@@ -11,7 +11,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              curl -o /tmp/sonarqube-plugins -s https://raw.githubusercontent.com/redhat-canada-gitops/catalog/master/sonarqube8/scripts/sonarqube-plugins;
+              curl -o /tmp/sonarqube-plugins -s https://raw.githubusercontent.com/redhat-cop/gitops-catalog/main/sonarqube8/scripts/sonarqube-plugins;
               chmod +x /tmp/sonarqube-plugins;
               /tmp/sonarqube-plugins
           imagePullPolicy: Always


### PR DESCRIPTION
Replace existing Nexus and Sonarqube script URLs that point to Red Hat Canada with new Red Hat CoP links