### PR TITLE
Do not force using an internal image

### DIFF
--- a/advanced-cluster-security-operator/instance/base/create-cluster-init-bundle-job.yaml
+++ b/advanced-cluster-security-operator/instance/base/create-cluster-init-bundle-job.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     spec:
       containers:
-        - image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        - image: registry.redhat.io/openshift4/ose-cli:latest
           env:
           - name: PASSWORD
             valueFrom:


### PR DESCRIPTION
Rather than using an internal image that *might* be there, use the upstream image so consumer of this argo app don't have to patch the deployment.
I believe it make more sense to have downstream users patching for downstream needs.