### PR TITLE
Add Sealed Secret Overlay to run controller with update status

### DIFF
--- a/sealed-secrets-operator/overlays/update-status/kustomization.yaml
+++ b/sealed-secrets-operator/overlays/update-status/kustomization.yaml
@@ -1,0 +1,17 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: sealed-secrets
+
+# Include the base Sealed Secrets manifests.
+bases:
+- ../../base
+
+# Remove the SCC requiring anyuid
+patchesJson6902:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: sealed-secrets-controller
+    path: patch-sealed-secrets.yaml

--- a/sealed-secrets-operator/overlays/update-status/patch-sealed-secrets.yaml
+++ b/sealed-secrets-operator/overlays/update-status/patch-sealed-secrets.yaml
@@ -1,0 +1,7 @@
+- op: remove
+  path: /spec/template/spec/containers/0/securityContext
+- op: remove
+  path: /spec/template/spec/securityContext
+- op: add
+  path: /spec/template/spec/containers/0/args
+  value: ["--update-status"]


### PR DESCRIPTION
Sealed Secret Resources will not show up healthy on ArgoCD starting with 2.0 and SealedSecret 0.16 unless you run the controller with --update-status to create a status block in SealedSecret resources.

I created a new overlay to support this use case

Ref:
https://argoproj.github.io/argo-cd/faq/#why-are-sealedsecret-resources-reporting-a-status
https://github.com/bitnami-labs/sealed-secrets/issues/555
https://github.com/bitnami-labs/sealed-secrets/blob/main/RELEASE-NOTES.md#v0150