### PR TITLE
Allow customization of installpan-approver Job

### DIFF
--- a/installplan-approver/base/installplan-approver-job.yaml
+++ b/installplan-approver/base/installplan-approver-job.yaml
@@ -11,7 +11,6 @@ spec:
             - /bin/bash
             - -c
             - |
-
               export HOME=/tmp/approver
 
               echo "Approving operator install.  Waiting a few seconds to make sure the InstallPlan gets created first."


### PR DESCRIPTION
Currently it is not possible to customize the Job because of an empty line here: https://github.com/redhat-cop/gitops-catalog/blob/e111499127d07bc11d54f494e121c2e901b9482e/installplan-approver/base/installplan-approver-job.yaml#L14

Error:
`error: yaml: line 31: mapping values are not allowed in this context`

<p>&nbsp;</p>

Deleting this empty line allows for example to rename the job with Kustomize:

```
example-customize-installplan-approver/
├── base/
│   └── kustomization.yaml
├── overlays/
│   └── production/
│       ├── patch-name-install-plan.yaml
│       └── kustomization.yaml
```

`base/kustomization.yaml`:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

bases:
- github.com/redhat-cop/gitops-catalog/installplan-approver/base?ref=main
```

`overlays/production/kustomization.yaml`:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
- ../../base

patchesJson6902:
- target:
    group: batch
    version: v1
    kind: Job
    name: installplan-approver
  path: patch-name-install-plan.yaml
```

`overlays/production/patch-name-install-plan.yaml`:
```yaml
- op: replace
  path: /metadata/name
  value: new-job-name-installplan-approver
```