### PR TITLE
Removed renaming of the URL for Ansible Automation Platform Operator

### DIFF
--- a/ansible-automation-platform/instance/overlays/default/kustomization.yaml
+++ b/ansible-automation-platform/instance/overlays/default/kustomization.yaml
@@ -5,11 +5,3 @@ kind: Kustomization
 bases:
   - ../../base
 
-patches:
-  - target:
-      kind: ConsoleLink
-      name: Controller
-    patch: |-
-      - op: replace
-        path: /spec/href
-        value: 'https://controller.apps-crc.testing'


### PR DESCRIPTION
fixes #94 per @pittar request to remove the customization of URL