### PR TITLE
iterate over all subscriptions in a namespace

### DIFF
--- a/installplan-approver/base/installplan-approver-job.yaml
+++ b/installplan-approver/base/installplan-approver-job.yaml
@@ -15,7 +15,7 @@ spec:
 
               echo "Approving operator install.  Waiting a few seconds to make sure the InstallPlan gets created first."
               sleep $SLEEP
-              for subscription in `oc get subscriptions.operators.coreos.com -o jsonpath='{.items[0].metadata.name}'`
+              for subscription in `oc get subscriptions.operators.coreos.com -o jsonpath='{.items[*].metadata.name}'`
               do
                 echo "Processing subscription '$subscription'"
 


### PR DESCRIPTION
Instead of approving just the installplan of the first element in the subscription array, you should iterate over all elements
(.items[0].metadata.name vs. .items[*].metadata.name)