### PR TITLE
Update overlay stable of service mesh to version 2.1.1

### DIFF
--- a/openshift-servicemesh/operator/overlays/stable/patch-channel.yaml
+++ b/openshift-servicemesh/operator/overlays/stable/patch-channel.yaml
@@ -3,4 +3,4 @@
   value: 'stable'
 - op: replace
   path: /spec/startingCSV
-  value: servicemeshoperator.v2.0.5.2
+  value: servicemeshoperator.v2.1.1


### PR DESCRIPTION
The stable channel for OpenShift Service Mesh Operator was updated from version 2.0.5.2 to version 2.1.1. Before the change, the operator was not being deployed at all.