### PR TITLE
Change the oauth/htpass overlay to use secretGenerator

### DIFF
--- a/oauth/README.md
+++ b/oauth/README.md
@@ -1,0 +1,59 @@
+# Configuring Identity Providers
+
+Do not use the `base` directory directly, as you will need to patch the `oauth` and add files to generate secrets.
+
+The current *overlays* available are for the following providers:
+* [htpass-idp](overlays/htpass-idp)
+* [htpass](overlays/htpass)
+
+## Prerequisites
+
+### For HTPasswd
+
+> There is an existent file `users.htpasswd` with a single user `admin:redhat` in case you want to use it for testing purposes.
+
+Have access to the `htpasswd` utility. On Red Hat Enterprise Linux this is available by installing the `httpd-tools` package.
+
+Create or update your file with a user name and hashed password:
+
+```shell
+$ htpasswd -c -B -b users.htpasswd <user_name> <password>
+```
+
+Continue to add or update credentials to the file:
+
+```shell
+$ htpasswd -B -b users.htpasswd <user_name> <password>
+```
+
+Replace the default file of the provider overlay:
+
+```shell
+$ cp -f users.htpasswd gitops-catalog/oauth/overlays/htpass/files/
+```
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can configure the identity provider based on the overlay of your choice by running from the root `gitops-catalog` directory.
+
+```
+oc apply -k oauth/overlays/<provider>
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/oauth/overlays/<provider>
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-cop/gitops-catalog/oauth/overlays/<provider>?ref=main
+```
+
+

--- a/oauth/overlays/htpass/files/users.htpasswd
+++ b/oauth/overlays/htpass/files/users.htpasswd
@@ -1,0 +1,1 @@
+admin:$2y$05$l6ymiu/e6vX0yBPKdltfqu3vdUiiJM4aJWXSTsw9y8WBZuzXhxV5O

--- a/oauth/overlays/htpass/kustomization.yaml
+++ b/oauth/overlays/htpass/kustomization.yaml
@@ -4,8 +4,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 bases:
   - ../../base
 
-resources:
-  - htpass-secret.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+
+secretGenerator:
+- name: htpass-secret
+  namespace: openshift-config
+  files:
+    - htpasswd=files/users.htpasswd
+  type: Opaque
 
 patchesJson6902:
   - target:


### PR DESCRIPTION
This is an updated to the current htpass overlay in oauth.

The kustomization now generates the secret using the secretGenerator based on the users.htpasswd found in the files directory.

The users.htpasswd file contains a single user admin with password redhat.
 
The README file was created to start documenting the providers.

The existent htpass-secret.yaml is not used and can be removed.
