### PR TITLE
Add openshift-image-registry for vsphere with vmdk

### DIFF
--- a/openshift-image-registry/README.md
+++ b/openshift-image-registry/README.md
@@ -1,0 +1,38 @@
+# OpenShift Image Registry
+
+Configures the integrated Image Registry
+
+Do not use the `base` directory directly, as you will need to patch the following based on the Storage you are using: 
+* the `rolloutStrategy`
+* the `storage`
+
+The current *overlays* available are:
+* [vsphere](overlays/vsphere). This enables the registry using a PVC with block storage.
+
+## Prerequisites
+
+Set the size of the PVC in the openshift-image-registry/overlays/provider/kustomization.yaml, the default is '5Gi'.
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install Logging infrastructure by running from the root `gitops-catalog` directory
+
+```
+oc apply -k openshift-image-registry/overlays/provider
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-image-registry/overlays/provider
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-cop/gitops-catalog/openshift-image-registry/overlays/provider?ref=main
+```

--- a/openshift-image-registry/base/image-registry-config.yaml
+++ b/openshift-image-registry/base/image-registry-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  name: cluster
+spec:
+  logLevel: Normal
+  managementState: Managed
+  observedConfig: null
+  operatorLogLevel: Normal
+  replicas: 1
+  requests:
+    read:
+      maxWaitInQueue: 0s
+    write:
+      maxWaitInQueue: 0s
+  rolloutStrategy: RollingUpdate
+  unsupportedConfigOverrides: null
+  defaultRoute: true
+  storage:
+    emptyDir: {}
+

--- a/openshift-image-registry/base/image-registry-pvc.yaml
+++ b/openshift-image-registry/base/image-registry-pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: image-registry-storage
+  namespace: openshift-image-registry
+spec:
+  accessModes:
+  - FROM_OVERLAY
+  resources:
+    requests:
+      storage: FROM_OVERLAY
+

--- a/openshift-image-registry/base/kustomization.yaml
+++ b/openshift-image-registry/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - image-registry-config.yaml
+  - image-registry-pvc.yaml
+

--- a/openshift-image-registry/overlays/vsphere/kustomization.yaml
+++ b/openshift-image-registry/overlays/vsphere/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patches:
+  - target:
+      kind: PersistentVolumeClaim
+      name: image-registry-storage
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: '5Gi'
+      - op: replace
+        path: /spec/accessModes
+        value:
+          - ReadWriteOnce
+  - target:
+      kind: Config
+      name: cluster
+    patch: |-
+      - op: add
+        path: /spec/storage
+        value:
+          pvc:
+            claim: 'image-registry-storage'
+      - op: replace
+        path: /spec/rolloutStrategy
+        value: 'Recreate'
+


### PR DESCRIPTION
Enable the internal image registry to work on vSphere with a simple PVC from the default block storage.
