### PR TITLE
Add cert-manager to the repository

### DIFF
--- a/cert-manager-operator/README.md
+++ b/cert-manager-operator/README.md
@@ -1,0 +1,15 @@
+### Introduction
+
+This deploys the cert-manager operator which is currently Tech Preview in 4.10. If you are not familiar with cert-manager, it provisions and manages TLS certificates for you automatically using one or more configured Issuers. It's great for providing a self-service capability around TLS certificates out of the OpenShift platform.
+
+Documentation on OpenShift cert-manager is available [here](https://docs.openshift.com/container-platform/4.10/security/cert_manager_operator/index.html).
+
+Community documentation for cert-manager is located [here](https://cert-manager.io/docs/).
+
+### Examples
+
+The examples folder contains some examples of how to use cert-manager including how to use it to provision OpenShift API and Wildcard certificates. There is a README associated with each example when you navigate to each folder.
+
+### TODO
+
+At some point I would like to make the examples directly deployable via a Helm chart. The examples are a case which would benefit from Helm templating versus patching in kustomize since many of the values can be derived from two parameters: cluster name and domain.

--- a/cert-manager-operator/examples/acs-central-certificate/README.md
+++ b/cert-manager-operator/examples/acs-central-certificate/README.md
@@ -1,0 +1,5 @@
+This is an example of using cert-manager to generate a TLS certificate for the Red Hat Advanced Cluster Security Central endpoint (i.e. `central-stackrox.<cluster>.<domain>.com`).
+
+To use this, update the certificate object to reflect your desired issuer and host name for the API endpoint. In the example we are using the letsencrypt-prod issuer in the examples folder.
+
+Note the certificate will overwrite the existing default certificate so you may wish to back that up first before using this.

--- a/cert-manager-operator/examples/acs-central-certificate/acs-central-certificate.yaml
+++ b/cert-manager-operator/examples/acs-central-certificate/acs-central-certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: central-acs-certificate
+  namespace: stackrox
+spec:
+  # Replace default secret since ACS doesn't support referencing a different secret
+  secretName: central-default-tls-cert
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+  - central-stackrox.apps.cluster.example.com

--- a/cert-manager-operator/examples/acs-central-certificate/kustomization.yaml
+++ b/cert-manager-operator/examples/acs-central-certificate/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- acs-central-certificate.yaml

--- a/cert-manager-operator/examples/letsencrypt-route53-issuer/README.md
+++ b/cert-manager-operator/examples/letsencrypt-route53-issuer/README.md
@@ -1,0 +1,18 @@
+This is an example issuer that uses letsencrypt (i.e. ACME) with a DNS challenge in AWS Route53. This example is useful when using AWS Route 53 as your DNS authority for OpenShift whether on-prem (like in my homelab) or in AWS itself. Documentation on Route 53 and cert-manager can be found here:
+
+https://cert-manager.io/docs/configuration/acme/dns01/route53/#creating-an-issuer-or-clusterissuer
+
+In order to this you need to update the staging and production letsencrypt issuers with the following information:
+
+* The email that you use with letsencrypt
+* The DNS Zone selector that is being managed by Route 53 that this issuer should be tied to (set to example.com here)
+* The region that is being used
+- The Access ID for the user in AWS that has permissions to work with Route 53, see the linked docs for IAM permissions required. This should absolutely not be the root AWS user
+
+You will also need to create a secret to hold the AWS secret key corresponding to the access ID provided:
+
+```
+oc create secret generic letsencrypt-aws --from-literal=secret-access-key=XXXXXXXX
+```
+
+Obviously from a GitOps perspective this secret needs to be stored securely using something like Sealed Secrets or Vault.

--- a/cert-manager-operator/examples/letsencrypt-route53-issuer/kustomization.yaml
+++ b/cert-manager-operator/examples/letsencrypt-route53-issuer/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+- letsencrypt-prod-cluster-issuer.yaml
+- letsencrypt-staging-cluster-issuer.yaml

--- a/cert-manager-operator/examples/letsencrypt-route53-issuer/letsencrypt-prod-cluster-issuer.yaml
+++ b/cert-manager-operator/examples/letsencrypt-route53-issuer/letsencrypt-prod-cluster-issuer.yaml
@@ -1,0 +1,22 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: someone@example.com
+    # This key doesn't exist, cert-manager creates it
+    privateKeySecretRef:
+      name: example-issuer-account-key
+    solvers:
+    - selector:
+        dnsZones:
+          - "example.com"
+      dns01:
+        route53:
+          region: ca-central-1
+          accessKeyID: XXXXXXXXXX
+          secretAccessKeySecretRef:
+            name: letsencrypt-aws
+            key: secret-access-key

--- a/cert-manager-operator/examples/letsencrypt-route53-issuer/letsencrypt-staging-cluster-issuer.yaml
+++ b/cert-manager-operator/examples/letsencrypt-route53-issuer/letsencrypt-staging-cluster-issuer.yaml
@@ -1,0 +1,22 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: someone@example.com
+    # This key doesn't exist, cert-manager creates it
+    privateKeySecretRef:
+      name: example-issuer-account-key
+    solvers:
+    - selector:
+        dnsZones:
+          - "example.com"
+      dns01:
+        route53:
+          region: ca-central-1
+          accessKeyID: XXXXXXXX
+          secretAccessKeySecretRef:
+            name: letsencrypt-aws
+            key: secret-access-key

--- a/cert-manager-operator/examples/openshift-api-certificate/README.md
+++ b/cert-manager-operator/examples/openshift-api-certificate/README.md
@@ -1,0 +1,3 @@
+This is an example of using cert-manager to generate a TLS certificate for the OpenShift API endpoint (i.e. `api.<cluster>.<domain>.com`) and patching it using an Argo CD post-sync hook.
+
+To use this, update the certificate object to reflect your desired issuer and host name for the API endpoint. In the example we are using the letsencrypt-prod issuer in the examples folder.

--- a/cert-manager-operator/examples/openshift-api-certificate/kustomization.yaml
+++ b/cert-manager-operator/examples/openshift-api-certificate/kustomization.yaml
@@ -1,0 +1,8 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: openshift-config
+
+resources:
+- openshift-api-certificate.yaml
+- patch-cluster-api-cert-job.yaml

--- a/cert-manager-operator/examples/openshift-api-certificate/openshift-api-certificate.yaml
+++ b/cert-manager-operator/examples/openshift-api-certificate/openshift-api-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openshift-api
+  namespace: openshift-config
+spec:
+  secretName: openshift-api-certificate
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+  - api.cluster.example.com

--- a/cert-manager-operator/examples/openshift-api-certificate/patch-cluster-api-cert-job.yaml
+++ b/cert-manager-operator/examples/openshift-api-certificate/patch-cluster-api-cert-job.yaml
@@ -1,0 +1,71 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: patch-cluster-api-cert
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - apiservers
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: patch-cluster-api-cert
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: patch-cluster-api-cert
+subjects:
+  - kind: ServiceAccount
+    name: patch-cluster-api-cert
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patch-cluster-api-cert
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: patch-cluster-api-cert
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          env:
+            - name: API_HOST_NAME
+              value: api.home.ocplab.com
+          command:
+            - /bin/bash
+            - -c
+            - |
+              #!/usr/bin/env bash
+              if oc get secret openshift-api-certificate -n openshift-config; then
+                oc patch apiserver cluster --type=merge -p '{"spec":{"servingCerts": {"namedCertificates": [{"names": ["'$API_HOST_NAME'"], "servingCertificate": {"name": "openshift-api-certificate"}}]}}}'
+              else
+                echo "Could not execute sync as secret 'openshift-api-certificate' in namespace 'openshift-config' does not exist, check status of CertificationRequest"
+                exit 1
+              fi
+          name: patch-cluster-api-cert
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30
+      serviceAccount: patch-cluster-api-cert
+      serviceAccountName: patch-cluster-api-cert

--- a/cert-manager-operator/examples/openshift-wildcard-certificate/README.md
+++ b/cert-manager-operator/examples/openshift-wildcard-certificate/README.md
@@ -1,0 +1,3 @@
+This is an example of using cert-manager to generate a TLS certificate for the OpenShift wildcard ingress endpoint (i.e. `*.apps.<cluster>.<domain>.com`) and patching it using an Argo CD post-sync hook.
+
+To use this, update the certificate object to reflect your desired issuer, cluster name and host name for the wildcard ingress endpoint. In the example we are using the letsencrypt-prod issuer in the examples folder.

--- a/cert-manager-operator/examples/openshift-wildcard-certificate/kustomization.yaml
+++ b/cert-manager-operator/examples/openshift-wildcard-certificate/kustomization.yaml
@@ -1,0 +1,8 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: openshift-ingress
+
+resources:
+- openshift-wildcard-certificate.yaml
+- patch-cluster-wildcard-cert-job.yaml

--- a/cert-manager-operator/examples/openshift-wildcard-certificate/openshift-wildcard-certificate.yaml
+++ b/cert-manager-operator/examples/openshift-wildcard-certificate/openshift-wildcard-certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openshift-wildcard
+  namespace: openshift-ingress
+spec:
+  secretName: openshift-wildcard-certificate
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: '*.apps.cluster.example.com'
+  dnsNames:
+  - '*.apps.cluster.example.com'

--- a/cert-manager-operator/examples/openshift-wildcard-certificate/patch-cluster-wildcard-cert-job.yaml
+++ b/cert-manager-operator/examples/openshift-wildcard-certificate/patch-cluster-wildcard-cert-job.yaml
@@ -1,0 +1,67 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: patch-cluster-wildcard-cert
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - ingresscontrollers
+    verbs:
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: patch-cluster-wildcard-cert
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: patch-cluster-wildcard-cert
+subjects:
+  - kind: ServiceAccount
+    name: patch-cluster-wildcard-cert
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patch-cluster-wildcard-cert
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: patch-cluster-wildcard-cert
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          command:
+            - /bin/bash
+            - -c
+            - |
+              #!/usr/bin/env bash
+              if oc get secret openshift-wildcard-certificate -n openshift-ingress; then
+                oc patch ingresscontroller default -n openshift-ingress-operator --type=merge --patch='{"spec": { "defaultCertificate": { "name": "openshift-wildcard-certificate" }}}'
+              else
+                echo "Could not execute sync as secret 'openshift-wildcard-certificate' in namespace 'openshift-ingress' does not exist, check status of CertificationRequest"
+                exit 1
+              fi
+          name: patch-cluster-wildcard-cert
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30
+      serviceAccount: patch-cluster-wildcard-cert
+      serviceAccountName: patch-cluster-wildcard-cert

--- a/cert-manager-operator/operator/base/kustomization.yaml
+++ b/cert-manager-operator/operator/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- operator-namespace.yaml
+- operator-group.yaml
+- subscription.yaml

--- a/cert-manager-operator/operator/base/operator-group.yaml
+++ b/cert-manager-operator/operator/base/operator-group.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cert-manager-operator
+spec: {}

--- a/cert-manager-operator/operator/base/operator-namespace.yaml
+++ b/cert-manager-operator/operator/base/operator-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name:  Red Hat Certificate Manager Operator
+  labels:
+    openshift.io/cluster-monitoring: 'true'
+  name: openshift-cert-manager-operator

--- a/cert-manager-operator/operator/base/subscription.yaml
+++ b/cert-manager-operator/operator/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: openshift-cert-manager-operator
+spec:
+  channel: tech-preview
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This PR adds support for the new Red Hat cert-manager operator that is in Tech Preview in 4.10. It also includes some examples of how to use it from a GitOps perspective to generate certs for OpenShift API and wildcard endpoints as well as for ACS.