### PR TITLE
remove references to startingCSV from docs

### DIFF
--- a/advanced-cluster-management/operator/README.md
+++ b/advanced-cluster-management/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the Advanced Cluster Management operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [release-2.3](overlays/release-2.3)

--- a/ansible-automation-platform/operator/README.md
+++ b/ansible-automation-platform/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the Ansible Automation Platform operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [early-access](overlays/early-access)

--- a/business-automation-operator/operator/README.md
+++ b/business-automation-operator/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the Business Automation operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable](overlays/stable)

--- a/container-security-operator/README.md
+++ b/container-security-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the Container Security operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [quay-v3.5](overlays/quay-v3.5)

--- a/elasticsearch-operator/README.md
+++ b/elasticsearch-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Elasticsearch operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [4.6](overlays/4.6)

--- a/gatekeeper-operator/README.md
+++ b/gatekeeper-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Gatekeeper operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [upstream](overlays/upstream)

--- a/jaeger-operator/overlays/README.md
+++ b/jaeger-operator/overlays/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Jaeger operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable](overlays/stable)

--- a/kiali-operator/README.md
+++ b/kiali-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the Kiali operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable](overlays/stable)

--- a/opendatahub-operator/README.md
+++ b/opendatahub-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenDataHub operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [beta](overlays/beta)

--- a/openshift-container-storage-noobaa/README.md
+++ b/openshift-container-storage-noobaa/README.md
@@ -12,7 +12,7 @@ First, install the [OpenShift Container Storage Operator](../openshift-container
 
 
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are:
 * [default](overlays/default) - a small storage cluster (10Gi).

--- a/openshift-container-storage-operator/README.md
+++ b/openshift-container-storage-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Container Storage operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable-4.6](overlays/stable-4.6)

--- a/openshift-data-foundation-operator/README.md
+++ b/openshift-data-foundation-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Data Foundation operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable-4.9](operator/overlays/stable-4.9)

--- a/openshift-gitops-operator/README.md
+++ b/openshift-gitops-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift GitOps (Argo CD) operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [preview](overlays/preview)

--- a/openshift-logging/operator/README.md
+++ b/openshift-logging/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Logging operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable](overlays/stable)

--- a/openshift-pipelines-operator/README.md
+++ b/openshift-pipelines-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Pipelines (Tekton) operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [ocp-46](overlays/ocp-46)

--- a/openshift-serverless/instance/knative-eventing/README.md
+++ b/openshift-serverless/instance/knative-eventing/README.md
@@ -6,7 +6,7 @@ Installs the Knative Eventing component of OpenShift Serverless.
 
 First, install the [OpenShift Serverless Operator](../../operator) in your cluster.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are:
 * [default](overlays/default)

--- a/openshift-serverless/instance/knative-serving/README.md
+++ b/openshift-serverless/instance/knative-serving/README.md
@@ -6,7 +6,7 @@ Installs the Knative Serving component of OpenShift Serverless.
 
 First, install the [OpenShift Serverless Operator](../openshift-serverless) in your cluster.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are:
 * [default](overlays/default)

--- a/openshift-serverless/operator/README.md
+++ b/openshift-serverless/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Serverless operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [4.5](overlays/4.5)

--- a/openshift-servicemesh/instance/README.md
+++ b/openshift-servicemesh/instance/README.md
@@ -13,7 +13,7 @@ First, install the following operators in your cluster:
 
 Review the [Service Mesh Install](https://docs.openshift.com/container-platform/4.7/service_mesh/v1x/installing-ossm.html#jaeger-operator-install-elasticsearch_installing-ossm-v1x) documentation for information on specific versions of the operators to install for your cluster version.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are:
 * [default](overlays/default)

--- a/openshift-servicemesh/operator/README.md
+++ b/openshift-servicemesh/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Service Mesh operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [1.0](overlays/1.0)

--- a/quay-registry-operator/README.md
+++ b/quay-registry-operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the OpenShift Quay Registry operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable-3.6](overlays/stable-3.6)

--- a/rhsso/operator/README.md
+++ b/rhsso/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the Red Hat Single Sign-On
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [alpha](overlays/alpha)

--- a/seldon-operator/operator/README.md
+++ b/seldon-operator/operator/README.md
@@ -2,7 +2,7 @@
 
 Installs the Seldon Certified Operator.
 
-Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
 
 The current *overlays* available are for the following channels:
 * [stable](overlays/stable)


### PR DESCRIPTION
The docs reference the patches for `channel` and `version` for operator subscriptions.  Since all of the `startingCSV` objects in Subscriptions have been removed there is no need for the docs to reference patching the version.