### PR TITLE
Add namespace for the rhacs operator

### DIFF
--- a/advanced-cluster-security-operator/operator/base/kustomization.yaml
+++ b/advanced-cluster-security-operator/operator/base/kustomization.yaml
@@ -7,4 +7,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-wave: "0"
 
 resources:
+  - namespace.yaml
+  - operatorgroup.yaml
   - subscription.yaml

--- a/advanced-cluster-security-operator/operator/base/namespace.yaml
+++ b/advanced-cluster-security-operator/operator/base/namespace.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
     openshift.io/display-name: Red Hat Advanced Cluster Security Operator
   name: rhacs-operator
 

--- a/advanced-cluster-security-operator/operator/base/namespace.yaml
+++ b/advanced-cluster-security-operator/operator/base/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    openshift.io/display-name: Red Hat Advanced Cluster Security Operator
+  name: rhacs-operator
+

--- a/advanced-cluster-security-operator/operator/base/operatorgroup.yaml
+++ b/advanced-cluster-security-operator/operator/base/operatorgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhacs-operator
+spec: {}
+

--- a/advanced-cluster-security-operator/operator/base/subscription.yaml
+++ b/advanced-cluster-security-operator/operator/base/subscription.yaml
@@ -1,8 +1,6 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  labels:
-    operators.coreos.com/rhacs-operator.openshift-operators: ''
   name: rhacs-operator
 spec:
   channel: patch-me-in-overlays

--- a/advanced-cluster-security-operator/operator/overlays/latest/kustomization.yaml
+++ b/advanced-cluster-security-operator/operator/overlays/latest/kustomization.yaml
@@ -1,7 +1,7 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
-namespace: openshift-operators
+namespace: rhacs-operator
 
 bases:
   - ../../base


### PR DESCRIPTION
The official documentation suggests using the namespace rhacs-operator to install the RHACS Operator.

The new namespace and operator group resources were created and the subscription pointed to that namespace. Now the RHACS is installed on rhacs-operator instead of openshift-operators.
