### PR TITLE
add job to enable odf plugin

### DIFF
--- a/openshift-data-foundation-operator/operator/base/enable-console-plugin-job.yaml
+++ b/openshift-data-foundation-operator/operator/base/enable-console-plugin-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: enable-odf-console-plugin
+  generateName: enable-odf-console-plugin-
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  template:
+    spec:
+      containers:
+      - name: labeler
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+        env:
+          - name: PLUGIN_NAME
+            value: 'odf-console'
+        command:
+          - /bin/bash
+          - -c
+          - |
+              echo "Attempting to enable ${PLUGIN_NAME} plugin"
+              echo ""
+
+              # Create the plugins section on the object if it doesn't exist
+              if [ -z $(oc get consoles.operator.openshift.io cluster -o=jsonpath='{.spec.plugins}') ]; then
+                echo "Creating plugins object"
+                oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": [] } }' --type=merge
+              fi
+
+              INSTALLED_PLUGINS=$(oc get consoles.operator.openshift.io cluster -o=jsonpath='{.spec.plugins}')
+              echo "Current plugins:"
+              echo ${INSTALLED_PLUGINS}
+
+              if [[ "${INSTALLED_PLUGINS}" == *"${PLUGIN_NAME}"* ]]; then
+                  echo "${PLUGIN_NAME} is already enabled"
+              else
+                  echo "Enabling plugin: ${PLUGIN_NAME}"
+                  oc patch consoles.operator.openshift.io cluster --type=json --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "'${PLUGIN_NAME}'"}]'
+              fi
+      restartPolicy: Never
+      serviceAccount: enable-odf-console-plugin
+      serviceAccountName: enable-odf-console-plugin
+  backoffLimit: 4

--- a/openshift-data-foundation-operator/operator/base/enable-console-plugin-rbac.yaml
+++ b/openshift-data-foundation-operator/operator/base/enable-console-plugin-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: enable-odf-console-plugin
+rules:
+  - apiGroups: ["operator.openshift.io"]
+    resources:
+      - consoles
+    verbs:
+      - get
+      - list
+      - patch
+      - label
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: enable-odf-console-plugin
+subjects:
+  - kind: ServiceAccount
+    name: enable-odf-console-plugin
+    namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enable-odf-console-plugin

--- a/openshift-data-foundation-operator/operator/base/enable-console-plugin-sa.yaml
+++ b/openshift-data-foundation-operator/operator/base/enable-console-plugin-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enable-odf-console-plugin

--- a/openshift-data-foundation-operator/operator/base/kustomization.yaml
+++ b/openshift-data-foundation-operator/operator/base/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 namespace: openshift-storage
 
 resources:
+  - enable-console-plugin-job.yaml
+  - enable-console-plugin-rbac.yaml
+  - enable-console-plugin-sa.yaml
   - openshift-data-foundation-console-plugin.yaml
   - openshift-data-foundation-operator-subscription.yaml
   - openshift-data-foundation-operator-operatorgroup.yaml


### PR DESCRIPTION
This is a follow up to #133 

I noticed today that simply adding the console plugin object is not enough and you have to add the plugin to the consoles object as well.

This update creates a job that patches the consoles object.  The job will check to see if the plugin is already listed in the object and if it isn't, the plugin is added to the list.

I'm not crazy about doing it this with a job but I didn't want to bring the console object into this operator base since other operators may also need to add to the list of plugins in the future.

If there is another simple way to handle a patch like this please let me know.