### PR TITLE
add odf instance example

### DIFF
--- a/openshift-data-foundation-operator/aggregate/overlays/aws-node-labeler/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/aws-node-labeler/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+bases:
+  - ../../../operator/overlays/stable-4.9
+  - ../../../instance/overlays/aws
+  - ../../../config-helpers/node-labeler/overlays/default

--- a/openshift-data-foundation-operator/aggregate/overlays/aws/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/aws/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+bases:
+  - ../../../operator/overlays/stable-4.9
+  - ../../../instance/overlays/aws

--- a/openshift-data-foundation-operator/config-helpers/README.md
+++ b/openshift-data-foundation-operator/config-helpers/README.md
@@ -1,0 +1,38 @@
+# OpenShift Data Foundation - Config Helpers
+
+Configuration helpers useful for automating some configurations needed to setup the operator.
+
+## Node Labeler
+
+The [node-labeler](/node-labeler/) is a helpful addition to any ODF instance overlays and can be used in combination with them.
+
+node-labeler creates a job that is responsible for applying the `cluster.ocs.openshift.io/openshift-storage=""` label to nodes needed for the ODF/OCS to install.  If your cluster does not have the minimum three worker nodes the job will fail.
+
+### Overlays
+
+The node-labeler config helper for this operator currently offeres the following *overlays*:
+* [default](overlays/default)
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install the Storage System by running from the root `gitops-catalog` directory
+
+```
+oc apply -k openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default?ref=main
+```

--- a/openshift-data-foundation-operator/config-helpers/node-labeler/base/kustomization.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - node-label-job.yaml
+  - rbac.yaml
+  - service-account.yaml

--- a/openshift-data-foundation-operator/config-helpers/node-labeler/base/node-label-job.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/base/node-label-job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: storage-cluster-label-worker-nodes
+  generateName: storage-cluster-label-worker-nodes-
+spec:
+  template:
+    spec:
+      containers:
+      - name: labeler
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+        env:
+          - name: selector
+            value: 'node-role.kubernetes.io/worker'
+        command:
+          - /bin/bash
+          - -c
+          - |
+            node_count=$(oc get nodes --selector=${selector} --output name | wc -l)
+            if [ ${node_count} -lt 3 ]; then
+              echo "Not enough selected nodes present in cluster"
+              oc get nodes --selector=${selector}
+              exit 1
+            fi
+            echo "Labling the following nodes"
+            oc get nodes --selector=${selector}
+            oc label nodes --selector=${selector} cluster.ocs.openshift.io/openshift-storage="" --overwrite=true
+      restartPolicy: Never
+      serviceAccount: ocs-node-labeler
+      serviceAccountName: ocs-node-labeler
+  backoffLimit: 4

--- a/openshift-data-foundation-operator/config-helpers/node-labeler/base/rbac.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/base/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-labeler
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - patch
+      - label
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-labeler
+  namespace: openshift-storage
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-5"
+subjects:
+  - kind: ServiceAccount
+    name: ocs-node-labeler
+    namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-labeler

--- a/openshift-data-foundation-operator/config-helpers/node-labeler/base/service-account.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/base/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocs-node-labeler
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"

--- a/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default/kustomization.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+bases:
+  - ../../base

--- a/openshift-data-foundation-operator/instance/README.md
+++ b/openshift-data-foundation-operator/instance/README.md
@@ -1,0 +1,58 @@
+# OpenShift Data Foundation
+
+Installs a basic Storage System using the OpenShift Data Foundation Operator.
+
+## Prerequisites
+
+OpenShift Data Foundation requires a minimum three worker nodes to install and configure a ceph cluster using OpenShift Data Foundation.
+
+First, install the [OpenShift Data Foundation Operator](../operator) in your cluster.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+## Overlays
+
+The instaconfnce options for this operator currently offeres the following *overlays*:
+* [aws](overlays/aws)
+
+### AWS
+
+[aws](overlays/aws) installs a basic StorageSystem.  The StorageSystem will configure the OpenShift Container Storage Operator and also install a StorageCluster and OCSInitilization object to configure the storage cluster.  The StorageCluster is configured to work with gp2 storage on an AWS cluster.
+
+In order for ODF/OCS to configure storage using this overlay it expects nodes with the following label to be present on the nodes ODF/OCS will install the cluster:
+
+```
+cluster.ocs.openshift.io/openshift-storage=""
+```
+
+You will need to manually add this label to nodes if they are not already present:
+
+```
+oc label nodes <node-name> cluster.ocs.openshift.io/openshift-storage="" --overwrite=true
+```
+
+For additional automation for labeling nodes see [node-labeler](../config-helpers/node-labeler/)
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install the Storage System by running from the root `gitops-catalog` directory
+
+```
+oc apply -k openshift-data-foundation-operator/instance/overlays/default
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/instance/overlays/default
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/instance/overlays/default?ref=main
+```

--- a/openshift-data-foundation-operator/instance/base/kustomization.yaml
+++ b/openshift-data-foundation-operator/instance/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - storagesystem.yaml

--- a/openshift-data-foundation-operator/instance/base/storagesystem.yaml
+++ b/openshift-data-foundation-operator/instance/base/storagesystem.yaml
@@ -1,0 +1,8 @@
+apiVersion: odf.openshift.io/v1alpha1
+kind: StorageSystem
+metadata:
+  name: ocs-storagecluster-storagesystem
+spec:
+  kind: storagecluster.ocs.openshift.io/v1
+  name: ocs-storagecluster
+  namespace: openshift-storage

--- a/openshift-data-foundation-operator/instance/overlays/aws/kustomization.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/aws/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+bases:
+  - ../../base
+
+resources:
+  - ocsinitialization.yaml
+  - storagecluster.yaml

--- a/openshift-data-foundation-operator/instance/overlays/aws/ocsinitialization.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/aws/ocsinitialization.yaml
@@ -1,0 +1,7 @@
+apiVersion: ocs.openshift.io/v1
+kind: OCSInitialization
+metadata:
+  name: ocsinit
+  namespace: openshift-storage
+spec:
+  enableCephTools: true

--- a/openshift-data-foundation-operator/instance/overlays/aws/storagecluster.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/aws/storagecluster.yaml
@@ -1,0 +1,40 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  arbiter: {}
+  encryption:
+    kms: {}
+  externalStorage: {}
+  managedResources:
+    cephBlockPools: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephFilesystems: {}
+    cephObjectStoreUsers: {}
+    cephObjectStores: {}
+  mirroring: {}
+  nodeTopologies: {}
+  storageDeviceSets:
+  - config: {}
+    count: 1
+    dataPVCTemplate:
+      metadata: {}
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Ti
+        storageClassName: gp2
+        volumeMode: Block
+      status: {}
+    name: ocs-deviceset-gp2
+    placement: {}
+    portable: true
+    preparePlacement: {}
+    replica: 3
+    resources: {}
+  version: 4.9.0


### PR DESCRIPTION
Created an example instance of ODF intended to work with AWS (tested on RHPDS).

Additionally created a `config-helpers` folder that contains a job to help label the worker nodes.  I went back and forth on if this should be included in the `aws` overlay or a separate `aws-node-labeler` overlay and ultimately settled on creating the `config-helpers` folder.  The node-labeler should work with any future instance overlays and keeping it in the `config-helpers` will prevent the files from having to be copied to multiple instances in the future.  I also didn't want to include in the in the base because it may not be wanted for some ODF deployments where other methods are being used for labeling the nodes.

Since this folder is a new pattern in the gitops-catalog I welcome any feedback!