### PR TITLE
Add latest channel, deprecate stable

### DIFF
--- a/openshift-pipelines-operator/overlays/latest/README.md
+++ b/openshift-pipelines-operator/overlays/latest/README.md
@@ -1,0 +1,1 @@
+Installs the *latest* channel of the Pipeline Operator which tracks the current version.

--- a/openshift-pipelines-operator/overlays/latest/kustomization.yaml
+++ b/openshift-pipelines-operator/overlays/latest/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: openshift-pipelines-operator
+      namespace: openshift-operators
+    path: patch-channel.yaml

--- a/openshift-pipelines-operator/overlays/latest/patch-channel.yaml
+++ b/openshift-pipelines-operator/overlays/latest/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: latest

--- a/openshift-pipelines-operator/overlays/stable/README.md
+++ b/openshift-pipelines-operator/overlays/stable/README.md
@@ -1,3 +1,4 @@
-Installs the *stable* channel version of the Pipeline Operator.
+Installs the *stable* channel version of the Pipeline Operator, note this channel has been deprecated in favor of the *latest* channel so please use that overlay instead going forward.
 
-**Version: 1.4.1**
+
+


### PR DESCRIPTION
Pipelines operator now uses latest channel to track newest releases instead of stable. This PR adds the latest channel and deprecates (but not removes) stable.

Longer term we should also create overlays for per version channels that are now available.