### PR TITLE
Add cluster role to new admin user

### DIFF
--- a/oauth/overlays/htpass/cluster-admin-role.yaml
+++ b/oauth/overlays/htpass/cluster-admin-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin-0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: admin

--- a/oauth/overlays/htpass/kustomization.yaml
+++ b/oauth/overlays/htpass/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 bases:
   - ../../base
+  - cluster-admin-role.yaml
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
I have added a `ClusterRoleBinding` resource to grant cluster-admin to the user `admin` created in the htpass overlay.

This is to get a proper admin account without having to execute additional commands.