### PR TITLE
 Add stable channel to external secrets operator

### DIFF
--- a/external-secrets-operator/operator/overlays/README.md
+++ b/external-secrets-operator/operator/overlays/README.md
@@ -2,3 +2,4 @@
 
 Channels:
 * [alpha](alpha)
+* [stable](stable)

--- a/external-secrets-operator/operator/overlays/stable/kustomization.yaml
+++ b/external-secrets-operator/operator/overlays/stable/kustomization.yaml
@@ -1,0 +1,16 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: openshift-operators
+
+bases:
+  - ../../base
+
+patches:
+  - target:
+      kind: Subscription
+      name: external-secrets-operator
+    patch: |-
+      - op: replace
+        path: /spec/channel
+        value: 'stable'


### PR DESCRIPTION
Add new external secrets operator channel:
- stable

It can also be seen here:
https://operatorhub.io/operator/external-secrets-operator/stable/external-secrets-operator.v0.5.9