### PR TITLE
Add elasticsearch-operator channels

### DIFF
--- a/elasticsearch-operator/README.md
+++ b/elasticsearch-operator/README.md
@@ -8,6 +8,11 @@ The current *overlays* available are for the following channels:
 * [4.6](overlays/4.6)
 * [5.0](overlays/5.0)
 * [stable](overlays/stable)
+* [stable-5.1](overlays/stable-5.1)
+* [stable-5.2](overlays/stable-5.2)
+* [stable-5.3](overlays/stable-5.3)
+* [stable-5.4](overlays/stable-5.4)
+* [stable-5.5](overlays/stable-5.5)
 
 ## Usage
 

--- a/elasticsearch-operator/overlays/stable-5.1/README.md
+++ b/elasticsearch-operator/overlays/stable-5.1/README.md
@@ -1,0 +1,3 @@
+Installs the *stable-5.1* channel version of the OpenShift Elasticsearch Operator
+
+**Version: 5.1.X**

--- a/elasticsearch-operator/overlays/stable-5.1/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.1/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: elasticsearch-operator
+      namespace: openshift-operators-redhat
+    path: patch-channel.yaml

--- a/elasticsearch-operator/overlays/stable-5.1/patch-channel.yaml
+++ b/elasticsearch-operator/overlays/stable-5.1/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-5.1'

--- a/elasticsearch-operator/overlays/stable-5.2/README.md
+++ b/elasticsearch-operator/overlays/stable-5.2/README.md
@@ -1,0 +1,3 @@
+Installs the *stable-5.2* channel version of the OpenShift Elasticsearch Operator
+
+**Version: 5.2.X**

--- a/elasticsearch-operator/overlays/stable-5.2/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.2/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: elasticsearch-operator
+      namespace: openshift-operators-redhat
+    path: patch-channel.yaml

--- a/elasticsearch-operator/overlays/stable-5.2/patch-channel.yaml
+++ b/elasticsearch-operator/overlays/stable-5.2/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-5.2'

--- a/elasticsearch-operator/overlays/stable-5.3/README.md
+++ b/elasticsearch-operator/overlays/stable-5.3/README.md
@@ -1,0 +1,3 @@
+Installs the *stable-5.3* channel version of the OpenShift Elasticsearch Operator
+
+**Version: 5.3.X**

--- a/elasticsearch-operator/overlays/stable-5.3/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.3/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: elasticsearch-operator
+      namespace: openshift-operators-redhat
+    path: patch-channel.yaml

--- a/elasticsearch-operator/overlays/stable-5.3/patch-channel.yaml
+++ b/elasticsearch-operator/overlays/stable-5.3/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-5.3'

--- a/elasticsearch-operator/overlays/stable-5.4/README.md
+++ b/elasticsearch-operator/overlays/stable-5.4/README.md
@@ -1,0 +1,3 @@
+Installs the *stable-5.4* channel version of the OpenShift Elasticsearch Operator
+
+**Version: 5.4.X**

--- a/elasticsearch-operator/overlays/stable-5.4/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.4/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: elasticsearch-operator
+      namespace: openshift-operators-redhat
+    path: patch-channel.yaml

--- a/elasticsearch-operator/overlays/stable-5.4/patch-channel.yaml
+++ b/elasticsearch-operator/overlays/stable-5.4/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-5.4'

--- a/elasticsearch-operator/overlays/stable-5.5/README.md
+++ b/elasticsearch-operator/overlays/stable-5.5/README.md
@@ -1,0 +1,3 @@
+Installs the *stable-5.5* channel version of the OpenShift Elasticsearch Operator
+
+**Version: 5.5.X**

--- a/elasticsearch-operator/overlays/stable-5.5/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.5/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: elasticsearch-operator
+      namespace: openshift-operators-redhat
+    path: patch-channel.yaml

--- a/elasticsearch-operator/overlays/stable-5.5/patch-channel.yaml
+++ b/elasticsearch-operator/overlays/stable-5.5/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-5.5'

--- a/elasticsearch-operator/overlays/stable/README.md
+++ b/elasticsearch-operator/overlays/stable/README.md
@@ -1,3 +1,3 @@
 Installs the *stable* channel version of the OpenShift Elasticsearch Operator
 
-**Version: 5.0.5**
+**Version: 5.5.X (depending on your OCP 4 version)**


### PR DESCRIPTION
Add new stable-5-x (5.1 to 5.5) channels for the elasticsearch operator

It covers OCP 4.7 until OCP 4.11.

Reference:
https://docs.openshift.com/container-platform/4.11/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying
