### PR TITLE
Add vsphere overlays to openshift-data-foundation-operator

### DIFF
--- a/openshift-data-foundation-operator/README.md
+++ b/openshift-data-foundation-operator/README.md
@@ -13,7 +13,7 @@ The current *overlays* available are for the following channels:
 If you have cloned the `gitops-catalog` repository, you can install the OpenShift Data Foundation operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
-oc apply -k openshift-data-foundation-operator/overlays/<channel>
+oc apply -k openshift-data-foundation-operator/operator/overlays/<channel>
 ```
 
 Or, without cloning:

--- a/openshift-data-foundation-operator/aggregate/overlays/vsphere-node-labeler/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/vsphere-node-labeler/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../../operator/overlays/stable-4.9
+  - ../../../instance/overlays/vsphere
+  - ../../../config-helpers/node-labeler/overlays/default

--- a/openshift-data-foundation-operator/aggregate/overlays/vsphere/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/vsphere/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../../operator/overlays/stable-4.9
+  - ../../../instance/overlays/vsphere

--- a/openshift-data-foundation-operator/instance/README.md
+++ b/openshift-data-foundation-operator/instance/README.md
@@ -14,12 +14,9 @@ Do not use the `base` directory directly, as you will need to patch the `channel
 
 The instaconfnce options for this operator currently offeres the following *overlays*:
 * [aws](overlays/aws)
+* [vsphere](overlays/vsphere)
 
-### AWS
-
-[aws](overlays/aws) installs a basic StorageSystem.  The StorageSystem will configure the OpenShift Container Storage Operator and also install a StorageCluster and OCSInitilization object to configure the storage cluster.  The StorageCluster is configured to work with gp2 storage on an AWS cluster.
-
-In order for ODF/OCS to configure storage using this overlay it expects nodes with the following label to be present on the nodes ODF/OCS will install the cluster:
+In order for ODF/OCS to configure storage using the overlays, they expect nodes with the following label to be present on the nodes ODF/OCS will install the cluster:
 
 ```
 cluster.ocs.openshift.io/openshift-storage=""
@@ -32,6 +29,14 @@ oc label nodes <node-name> cluster.ocs.openshift.io/openshift-storage="" --overw
 ```
 
 For additional automation for labeling nodes see [node-labeler](../config-helpers/node-labeler/)
+
+### AWS
+
+[aws](overlays/aws) installs a basic StorageSystem.  The StorageSystem will configure the OpenShift Container Storage Operator and also install a StorageCluster and OCSInitilization object to configure the storage cluster.  The StorageCluster is configured to work with gp2 storage on an AWS cluster.
+
+### vSphere
+
+[vsphere](overlays/vsphere) installs a basic StorageSystem.  The StorageSystem will configure the OpenShift Container Storage Operator and also install a StorageCluster and OCSInitilization object to configure the storage cluster.  The StorageCluster is configured to work with thin storage on a vSphere cluster and enables flexible scaling to distribute devices evenly across all nodes, regardless of distribution in zones or racks.   
 
 ## Usage
 

--- a/openshift-data-foundation-operator/instance/overlays/vsphere/kustomization.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/vsphere/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+bases:
+  - ../../base
+
+resources:
+  - ocsinitialization.yaml
+  - storagecluster.yaml

--- a/openshift-data-foundation-operator/instance/overlays/vsphere/ocsinitialization.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/vsphere/ocsinitialization.yaml
@@ -1,0 +1,7 @@
+apiVersion: ocs.openshift.io/v1
+kind: OCSInitialization
+metadata:
+  name: ocsinit
+  namespace: openshift-storage
+spec:
+  enableCephTools: true

--- a/openshift-data-foundation-operator/instance/overlays/vsphere/storagecluster.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/vsphere/storagecluster.yaml
@@ -1,0 +1,41 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  arbiter: {}
+  encryption:
+    kms: {}
+  externalStorage: {}
+  flexibleScaling: true
+  managedResources:
+    cephBlockPools: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephFilesystems: {}
+    cephObjectStoreUsers: {}
+    cephObjectStores: {}
+  mirroring: {}
+  nodeTopologies: {}
+  storageDeviceSets:
+  - config: {}
+    count: 1
+    dataPVCTemplate:
+      metadata: {}
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Ti
+        storageClassName: thin
+        volumeMode: Block
+      status: {}
+    name: ocs-deviceset-thin
+    placement: {}
+    portable: true
+    preparePlacement: {}
+    replica: 3
+    resources: {}
+  version: 4.9.0


### PR DESCRIPTION
Adds new vSphere overlays to the OpenShift Data Foundation Operator with `thin` storage and flexible scaling enabled, as vSphere clusters don't have zones/racks by default.