### PR TITLE
Add yamllint action

### DIFF
--- a/.github/workflows/kustomize-lint.yaml
+++ b/.github/workflows/kustomize-lint.yaml
@@ -21,3 +21,19 @@ jobs:
         uses: actions/checkout@v2
       - name: Validate Manifests
         run: ./hack/validate_manifests.sh
+  yaml-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint
+      - name: Validate Manifests
+        run: yamllint . -f github


### PR DESCRIPTION
 Closes #62 

Add GitHub action to run yamllint to enforce yaml standards.

Yamllint action includes ability to annotate format issues automatically.

Example of bad commit:

https://github.com/strangiato/gitops-catalog/actions/runs/2952926756

<img width="1423" alt="Screen Shot 2022-08-29 at 8 30 44 PM" src="https://user-images.githubusercontent.com/1628206/187327945-6e0f0809-2649-4720-b47b-2ef2a6acb203.png">

<img width="1391" alt="Screen Shot 2022-08-29 at 8 30 56 PM" src="https://user-images.githubusercontent.com/1628206/187327963-ce7b2384-1e1f-4a99-8e2e-669bdefe31d9.png">
