### PR TITLE
Make storagecluster version dynamic

### DIFF
--- a/openshift-data-foundation-operator/instance/overlays/aws/storagecluster.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/aws/storagecluster.yaml
@@ -37,4 +37,5 @@ spec:
       preparePlacement: {}
       replica: 3
       resources: {}
-  version: 4.9.0
+  # Allow ODF to set version dynamically when applied
+  # version: 4.9.0

--- a/openshift-data-foundation-operator/instance/overlays/vsphere/storagecluster.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/vsphere/storagecluster.yaml
@@ -38,4 +38,5 @@ spec:
       preparePlacement: {}
       replica: 3
       resources: {}
-  version: 4.9.0
+  # Allow ODF to set version dynamically when applied
+  # version: 4.9.0


### PR DESCRIPTION
Version is currently hardcoded into the instance examples.  If the version is not included in the object ODF will dynamically set the version based on the operator version.