### PR TITLE
Fix typo in container-security-operator readme

### DIFF
--- a/container-security-operator/README.md
+++ b/container-security-operator/README.md
@@ -7,19 +7,20 @@ Do not use the `base` directory directly, as you will need to patch the `channel
 The current *overlays* available are for the following channels:
 * [quay-v3.5](overlays/quay-v3.5)
 * [stable-3.6](overlays/stable-3.6)
+* [stable-3.7](overlays/stable-3.7)
 
 ## Usage
 
 If you have cloned the `gitops-catalog` repository, you can install the Ansible Automation Platform operator based on the overlay of your choice by running from the root `gitops-catalog` directory
 
 ```
-oc apply -k container-security-operator/operator/overlays/<channel>
+oc apply -k container-security-operator/overlays/<channel>
 ```
 
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-cop/gitops-catalog/container-security-operator/operator/overlays/<channel>
+oc apply -k https://github.com/redhat-cop/gitops-catalog/container-security-operator/overlays/<channel>
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -28,5 +29,5 @@ As part of a different overlay in your own GitOps repo:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - github.com/redhat-cop/gitops-catalog/container-security-operator/operator/overlays/<channel>?ref=main
+  - github.com/redhat-cop/gitops-catalog/container-security-operator/overlays/<channel>?ref=main
 ```


### PR DESCRIPTION
The path `container-security-operator/operator/overlays/<channel>` does not exist, removing the `operator` directory from the path.