### PR TITLE
Update kustomization.yaml files to support Kustomize 5.x

### DIFF
--- a/advanced-cluster-management/instance/base/kustomization.yaml
+++ b/advanced-cluster-management/instance/base/kustomization.yaml
@@ -1,7 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - multiclusterhub.yaml
-  - subscription-admin.yaml
+- multiclusterhub.yaml
+- subscription-admin.yaml

--- a/advanced-cluster-management/instance/observability/kustomization.yaml
+++ b/advanced-cluster-management/instance/observability/kustomization.yaml
@@ -1,9 +1,8 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - 00-namespace.yaml
-  - 01-acm-observability-bucket.yaml
-  - 02-install-observability.yaml
-  - 03-multiclusterobservability.yaml
+- 00-namespace.yaml
+- 01-acm-observability-bucket.yaml
+- 02-install-observability.yaml
+- 03-multiclusterobservability.yaml

--- a/advanced-cluster-management/operator/base/kustomization.yaml
+++ b/advanced-cluster-management/operator/base/kustomization.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - install.yaml
+- install.yaml

--- a/advanced-cluster-management/operator/overlays/release-2.3/kustomization.yaml
+++ b/advanced-cluster-management/operator/overlays/release-2.3/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: advanced-cluster-management
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-2.3'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-2.3'
+  target:
+    kind: Subscription
+    name: advanced-cluster-management
+resources:
+- ../../base

--- a/advanced-cluster-management/operator/overlays/release-2.4/kustomization.yaml
+++ b/advanced-cluster-management/operator/overlays/release-2.4/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: advanced-cluster-management
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-2.4'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-2.4'
+  target:
+    kind: Subscription
+    name: advanced-cluster-management
+resources:
+- ../../base

--- a/advanced-cluster-management/operator/overlays/release-2.5/kustomization.yaml
+++ b/advanced-cluster-management/operator/overlays/release-2.5/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: advanced-cluster-management
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-2.5'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-2.5'
+  target:
+    kind: Subscription
+    name: advanced-cluster-management
+resources:
+- ../../base

--- a/advanced-cluster-management/operator/overlays/release-2.6/kustomization.yaml
+++ b/advanced-cluster-management/operator/overlays/release-2.6/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: advanced-cluster-management
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-2.6'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-2.6'
+  target:
+    kind: Subscription
+    name: advanced-cluster-management
+resources:
+- ../../base

--- a/advanced-cluster-management/operator/overlays/release-2.7/kustomization.yaml
+++ b/advanced-cluster-management/operator/overlays/release-2.7/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: advanced-cluster-management
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-2.7'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-2.7'
+  target:
+    kind: Subscription
+    name: advanced-cluster-management
+resources:
+- ../../base

--- a/advanced-cluster-security-operator/aggregate/default/kustomization.yaml
+++ b/advanced-cluster-security-operator/aggregate/default/kustomization.yaml
@@ -5,5 +5,5 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - ../../operator/overlays/latest
-  - ../../instance/overlays/default
+- ../../operator/overlays/latest
+- ../../instance/overlays/default

--- a/advanced-cluster-security-operator/aggregate/minimal/kustomization.yaml
+++ b/advanced-cluster-security-operator/aggregate/minimal/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../default
 
-patchesJson6902:
-  - path: patch-resources.yaml
-    target:
-      group: platform.stackrox.io
-      kind: Central
-      name: central
-      version: v1alpha1
+resources:
+- ../default
+patches:
+- path: patch-resources.yaml
+  target:
+    group: platform.stackrox.io
+    kind: Central
+    name: central
+    version: v1alpha1

--- a/advanced-cluster-security-operator/instance/base/kustomization.yaml
+++ b/advanced-cluster-security-operator/instance/base/kustomization.yaml
@@ -7,8 +7,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - namespace.yaml
-  - create-cluster-init-bundle-sa.yaml
-  - central.yaml
-  - create-cluster-init-bundle-job.yaml
-  - secured-cluster.yaml
+- namespace.yaml
+- create-cluster-init-bundle-sa.yaml
+- central.yaml
+- create-cluster-init-bundle-job.yaml
+- secured-cluster.yaml

--- a/advanced-cluster-security-operator/instance/overlays/default/kustomization.yaml
+++ b/advanced-cluster-security-operator/instance/overlays/default/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 namespace: stackrox
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/advanced-cluster-security-operator/instance/overlays/internal-registry-integration/kustomization.yaml
+++ b/advanced-cluster-security-operator/instance/overlays/internal-registry-integration/kustomization.yaml
@@ -3,10 +3,9 @@ kind: Kustomization
 
 namespace: stackrox
 
-bases:
-  - ../../base
 
 resources:
-  - stackrox-image-puller-sa.yaml
-  - stackrox-image-integration-update-job-sa.yaml
-  - stackrox-image-integration-update-job.yaml
+- stackrox-image-puller-sa.yaml
+- stackrox-image-integration-update-job-sa.yaml
+- stackrox-image-integration-update-job.yaml
+- ../../base

--- a/advanced-cluster-security-operator/operator/base/kustomization.yaml
+++ b/advanced-cluster-security-operator/operator/base/kustomization.yaml
@@ -7,6 +7,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-wave: "0"
 
 resources:
-  - namespace.yaml
-  - operatorgroup.yaml
-  - subscription.yaml
+- namespace.yaml
+- operatorgroup.yaml
+- subscription.yaml

--- a/advanced-cluster-security-operator/operator/overlays/latest/kustomization.yaml
+++ b/advanced-cluster-security-operator/operator/overlays/latest/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: rhacs-operator
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: rhacs-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'latest'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'latest'
+  target:
+    kind: Subscription
+    name: rhacs-operator
+resources:
+- ../../base

--- a/amq-streams-operator/operator/base/kustomization.yaml
+++ b/amq-streams-operator/operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - amq-streams-operator-subscription.yaml
+- amq-streams-operator-subscription.yaml

--- a/amq-streams-operator/operator/overlays/amq-streams-1.8.x/kustomization.yaml
+++ b/amq-streams-operator/operator/overlays/amq-streams-1.8.x/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: amq-streams
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: amq-streams
+    namespace: openshift-operators
+    version: v1alpha1

--- a/amq-streams-operator/operator/overlays/amq-streams-1.x/kustomization.yaml
+++ b/amq-streams-operator/operator/overlays/amq-streams-1.x/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: amq-streams
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: amq-streams
+    namespace: openshift-operators
+    version: v1alpha1

--- a/amq-streams-operator/operator/overlays/amq-streams-2.0.x/kustomization.yaml
+++ b/amq-streams-operator/operator/overlays/amq-streams-2.0.x/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: amq-streams
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: amq-streams
+    namespace: openshift-operators
+    version: v1alpha1

--- a/amq-streams-operator/operator/overlays/amq-streams-2.1.x/kustomization.yaml
+++ b/amq-streams-operator/operator/overlays/amq-streams-2.1.x/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: amq-streams
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: amq-streams
+    namespace: openshift-operators
+    version: v1alpha1

--- a/amq-streams-operator/operator/overlays/amq-streams-2.x/kustomization.yaml
+++ b/amq-streams-operator/operator/overlays/amq-streams-2.x/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: amq-streams
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: amq-streams
+    namespace: openshift-operators
+    version: v1alpha1

--- a/amq-streams-operator/operator/overlays/stable/kustomization.yaml
+++ b/amq-streams-operator/operator/overlays/stable/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: amq-streams
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: amq-streams
+    namespace: openshift-operators
+    version: v1alpha1

--- a/ansible-automation-platform/hub-instance/base/kustomization.yaml
+++ b/ansible-automation-platform/hub-instance/base/kustomization.yaml
@@ -1,7 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - automationhub.yaml
-  - console-link.yaml
+- automationhub.yaml
+- console-link.yaml

--- a/ansible-automation-platform/hub-instance/overlays/default/kustomization.yaml
+++ b/ansible-automation-platform/hub-instance/overlays/default/kustomization.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/ansible-automation-platform/instance/base/kustomization.yaml
+++ b/ansible-automation-platform/instance/base/kustomization.yaml
@@ -1,7 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - automationcontroller.yaml
-  - console-link.yaml
+- automationcontroller.yaml
+- console-link.yaml

--- a/ansible-automation-platform/instance/overlays/default/kustomization.yaml
+++ b/ansible-automation-platform/instance/overlays/default/kustomization.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/ansible-automation-platform/operator/base/kustomization.yaml
+++ b/ansible-automation-platform/operator/base/kustomization.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - install.yaml
+- install.yaml

--- a/ansible-automation-platform/operator/overlays/stable-2.1-cluster-scoped/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.1-cluster-scoped/kustomization.yaml
@@ -3,23 +3,22 @@ kind: Kustomization
 
 namespace: ansible-automation-platform
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: OperatorGroup
-      name: ansible-automation-platform-operator
-    patch: |-
-      - op: replace
-        path: /spec/targetNamespaces
-        value: []
+- patch: |-
+    - op: replace
+      path: /spec/targetNamespaces
+      value: []
+  target:
+    kind: OperatorGroup
+    name: ansible-automation-platform-operator
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ansible-automation-platform
+    namespace: ansible-automation-platform
+    version: v1alpha1
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ansible-automation-platform
-      namespace: ansible-automation-platform
-    path: patch-channel.yaml
+resources:
+- ../../base

--- a/ansible-automation-platform/operator/overlays/stable-2.1/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.1/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: ansible-automation-platform
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ansible-automation-platform
-      namespace: ansible-automation-platform
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ansible-automation-platform
+    namespace: ansible-automation-platform
+    version: v1alpha1

--- a/ansible-automation-platform/operator/overlays/stable-2.2-cluster-scoped/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.2-cluster-scoped/kustomization.yaml
@@ -3,23 +3,22 @@ kind: Kustomization
 
 namespace: ansible-automation-platform
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: OperatorGroup
-      name: ansible-automation-platform-operator
-    patch: |-
-      - op: replace
-        path: /spec/targetNamespaces
-        value: []
+- patch: |-
+    - op: replace
+      path: /spec/targetNamespaces
+      value: []
+  target:
+    kind: OperatorGroup
+    name: ansible-automation-platform-operator
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ansible-automation-platform
+    namespace: ansible-automation-platform
+    version: v1alpha1
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ansible-automation-platform
-      namespace: ansible-automation-platform
-    path: patch-channel.yaml
+resources:
+- ../../base

--- a/ansible-automation-platform/operator/overlays/stable-2.2/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.2/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: ansible-automation-platform
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ansible-automation-platform
-      namespace: ansible-automation-platform
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ansible-automation-platform
+    namespace: ansible-automation-platform
+    version: v1alpha1

--- a/ansible-automation-platform/operator/overlays/stable-2.3-cluster-scoped/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.3-cluster-scoped/kustomization.yaml
@@ -3,23 +3,22 @@ kind: Kustomization
 
 namespace: ansible-automation-platform
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: OperatorGroup
-      name: ansible-automation-platform-operator
-    patch: |-
-      - op: replace
-        path: /spec/targetNamespaces
-        value: []
+- patch: |-
+    - op: replace
+      path: /spec/targetNamespaces
+      value: []
+  target:
+    kind: OperatorGroup
+    name: ansible-automation-platform-operator
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ansible-automation-platform
+    namespace: ansible-automation-platform
+    version: v1alpha1
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ansible-automation-platform
-      namespace: ansible-automation-platform
-    path: patch-channel.yaml
+resources:
+- ../../base

--- a/ansible-automation-platform/operator/overlays/stable-2.3/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.3/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: ansible-automation-platform
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ansible-automation-platform
-      namespace: ansible-automation-platform
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ansible-automation-platform
+    namespace: ansible-automation-platform
+    version: v1alpha1

--- a/apicast/base/kustomization.yaml
+++ b/apicast/base/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - apicast-dc.yaml
-  - apicast-svc.yaml
-  - apicast-route.yaml
+- apicast-dc.yaml
+- apicast-svc.yaml
+- apicast-route.yaml

--- a/apicast/overlays/default/kustomization.yaml
+++ b/apicast/overlays/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../prod
-  - ../stage
+resources:
+- ../prod
+- ../stage

--- a/apicast/overlays/prod/kustomization.yaml
+++ b/apicast/overlays/prod/kustomization.yaml
@@ -3,29 +3,28 @@ kind: Kustomization
 
 nameSuffix: -prod
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      version: v1
-      group: apps.openshift.io
-      kind: DeploymentConfig
-      name: apicast-prod
-    path: patch-prod-dc.yaml
-  - target:
-      version: v1
-      group: route.openshift.io
-      kind: Route
-      name: apicast-prod
-    path: patch-prod-route.yaml
-  - target:
-      version: v1
-      group: ""
-      kind: Service
-      name: apicast-prod
-    path: patch-prod-svc.yaml
 
 
 transformers:
-  - update-k8s-labels.yaml
+- update-k8s-labels.yaml
+resources:
+- ../../base
+patches:
+- path: patch-prod-dc.yaml
+  target:
+    group: apps.openshift.io
+    kind: DeploymentConfig
+    name: apicast-prod
+    version: v1
+- path: patch-prod-route.yaml
+  target:
+    group: route.openshift.io
+    kind: Route
+    name: apicast-prod
+    version: v1
+- path: patch-prod-svc.yaml
+  target:
+    kind: Service
+    name: apicast-prod
+    version: v1

--- a/apicast/overlays/stage/kustomization.yaml
+++ b/apicast/overlays/stage/kustomization.yaml
@@ -3,29 +3,28 @@ kind: Kustomization
 
 nameSuffix: -stage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      version: v1
-      group: apps.openshift.io
-      kind: DeploymentConfig
-      name: apicast-stage
-    path: patch-stage-dc.yaml
-  - target:
-      version: v1
-      group: route.openshift.io
-      kind: Route
-      name: apicast-stage
-    path: patch-stage-route.yaml
-  - target:
-      version: v1
-      group: ""
-      kind: Service
-      name: apicast-stage
-    path: patch-stage-svc.yaml
 
 
 transformers:
-  - update-k8s-labels.yaml
+- update-k8s-labels.yaml
+resources:
+- ../../base
+patches:
+- path: patch-stage-dc.yaml
+  target:
+    group: apps.openshift.io
+    kind: DeploymentConfig
+    name: apicast-stage
+    version: v1
+- path: patch-stage-route.yaml
+  target:
+    group: route.openshift.io
+    kind: Route
+    name: apicast-stage
+    version: v1
+- path: patch-stage-svc.yaml
+  target:
+    kind: Service
+    name: apicast-stage
+    version: v1

--- a/business-automation-operator/aggregate/overlays/default/kustomization.yaml
+++ b/business-automation-operator/aggregate/overlays/default/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../../instance/overlays/default
-  - ../../../operator/overlays/stable
+resources:
+- ../../../instance/overlays/default
+- ../../../operator/overlays/stable

--- a/business-automation-operator/instance/base/kustomization.yaml
+++ b/business-automation-operator/instance/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - kia-app.yaml
+- kia-app.yaml

--- a/business-automation-operator/instance/overlays/default/kustomization.yaml
+++ b/business-automation-operator/instance/overlays/default/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/business-automation-operator/operator/base/kustomization.yaml
+++ b/business-automation-operator/operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - businessautomation-subscription.yaml
+- businessautomation-subscription.yaml

--- a/business-automation-operator/operator/overlays/stable/kustomization.yaml
+++ b/business-automation-operator/operator/overlays/stable/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: businessautomation-operator
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: businessautomation-operator
+    version: v1alpha1
+resources:
+- ../../base

--- a/cert-manager-operator/examples/acs-central-certificate/kustomization.yaml
+++ b/cert-manager-operator/examples/acs-central-certificate/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - acs-central-certificate.yaml
+- acs-central-certificate.yaml

--- a/cert-manager-operator/examples/letsencrypt-route53-issuer/kustomization.yaml
+++ b/cert-manager-operator/examples/letsencrypt-route53-issuer/kustomization.yaml
@@ -5,5 +5,5 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - letsencrypt-prod-cluster-issuer.yaml
-  - letsencrypt-staging-cluster-issuer.yaml
+- letsencrypt-prod-cluster-issuer.yaml
+- letsencrypt-staging-cluster-issuer.yaml

--- a/cert-manager-operator/examples/openshift-api-certificate/kustomization.yaml
+++ b/cert-manager-operator/examples/openshift-api-certificate/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-config
 
 resources:
-  - openshift-api-certificate.yaml
-  - patch-cluster-api-cert-job.yaml
+- openshift-api-certificate.yaml
+- patch-cluster-api-cert-job.yaml

--- a/cert-manager-operator/examples/openshift-wildcard-certificate/kustomization.yaml
+++ b/cert-manager-operator/examples/openshift-wildcard-certificate/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-ingress
 
 resources:
-  - openshift-wildcard-certificate.yaml
-  - patch-cluster-wildcard-cert-job.yaml
+- openshift-wildcard-certificate.yaml
+- patch-cluster-wildcard-cert-job.yaml

--- a/cert-manager-operator/operator/base/kustomization.yaml
+++ b/cert-manager-operator/operator/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: openshift-cert-manager-operator
 
 resources:
-  - operator-namespace.yaml
-  - operator-group.yaml
-  - subscription.yaml
+- operator-namespace.yaml
+- operator-group.yaml
+- subscription.yaml

--- a/compliance-operator/aggregate/demo/kustomization.yaml
+++ b/compliance-operator/aggregate/demo/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-compliance
 
 commonAnnotations:
-  argocd.argoproj.io/sync-wave: "1"
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  argocd.argoproj.io/sync-wave: "1"
 
 resources:
-  - ../../operator/overlays/release-0.1
-  - demo-scan-setting.yaml
-  - demo-scan-setting-binding.yaml
+- ../../operator/overlays/release-0.1
+- demo-scan-setting.yaml
+- demo-scan-setting-binding.yaml

--- a/compliance-operator/aggregate/scheduled/kustomization.yaml
+++ b/compliance-operator/aggregate/scheduled/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-compliance
 
 commonAnnotations:
-  argocd.argoproj.io/sync-wave: "1"
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  argocd.argoproj.io/sync-wave: "1"
 
 resources:
-  - ../../operator/overlays/release-0.1
-  - moderate-scan-setting.yaml
-  - moderate-scan-setting-binding.yaml
+- ../../operator/overlays/release-0.1
+- moderate-scan-setting.yaml
+- moderate-scan-setting-binding.yaml

--- a/compliance-operator/instance/overlays/ocp-cis/kustomization.yaml
+++ b/compliance-operator/instance/overlays/ocp-cis/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-compliance
 
 commonAnnotations:
-  argocd.argoproj.io/sync-wave: "1"
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  argocd.argoproj.io/sync-wave: "1"
 
 resources:
-  - ocp-cis-scansettingbinding.yaml
+- ocp-cis-scansettingbinding.yaml

--- a/compliance-operator/operator/base/kustomization.yaml
+++ b/compliance-operator/operator/base/kustomization.yaml
@@ -7,15 +7,15 @@ commonAnnotations:
   argocd.argoproj.io/sync-wave: "0"
 
 resources:
-  - namespace.yaml
-  - compliance-operator-subscription.yaml
-  - compliance-operator-operatorgroup.yaml
+- namespace.yaml
+- compliance-operator-subscription.yaml
+- compliance-operator-operatorgroup.yaml
 
 patches:
-  - target:
-      kind: Subscription
-      name: compliance-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-0.1'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-0.1'
+  target:
+    kind: Subscription
+    name: compliance-operator

--- a/compliance-operator/operator/overlays/release-0.1/kustomization.yaml
+++ b/compliance-operator/operator/overlays/release-0.1/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: openshift-compliance
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: compliance-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-0.1'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-0.1'
+  target:
+    kind: Subscription
+    name: compliance-operator
+resources:
+- ../../base

--- a/container-security-operator/base/kustomization.yaml
+++ b/container-security-operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-operators
 
 resources:
-  - container-security-operator-subscription.yaml
+- container-security-operator-subscription.yaml

--- a/container-security-operator/overlays/quay-v3.5/kustomization.yaml
+++ b/container-security-operator/overlays/quay-v3.5/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: container-security-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'quay-v3.5'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'quay-v3.5'
+  target:
+    kind: Subscription
+    name: container-security-operator
+resources:
+- ../../base

--- a/container-security-operator/overlays/stable-3.6/kustomization.yaml
+++ b/container-security-operator/overlays/stable-3.6/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: container-security-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable-3.6'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable-3.6'
+  target:
+    kind: Subscription
+    name: container-security-operator
+resources:
+- ../../base

--- a/container-security-operator/overlays/stable-3.7/kustomization.yaml
+++ b/container-security-operator/overlays/stable-3.7/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: container-security-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable-3.7'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable-3.7'
+  target:
+    kind: Subscription
+    name: container-security-operator
+resources:
+- ../../base

--- a/cost-management-operator/base/instance/kustomization.yaml
+++ b/cost-management-operator/base/instance/kustomization.yaml
@@ -2,4 +2,4 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 resources:
-  - costmanagement-metrics-instance.yaml
+- costmanagement-metrics-instance.yaml

--- a/cost-management-operator/base/operator/kustomization.yaml
+++ b/cost-management-operator/base/operator/kustomization.yaml
@@ -2,6 +2,6 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 resources:
-  - costmanagement-metrics-operator-namespace.yaml
-  - costmanagement-metrics-operator-operatorgroup.yaml
-  - costmanagement-metrics-operator-subscription.yaml
+- costmanagement-metrics-operator-namespace.yaml
+- costmanagement-metrics-operator-operatorgroup.yaml
+- costmanagement-metrics-operator-subscription.yaml

--- a/cost-management-operator/overlays/aggregate/kustomization.yaml
+++ b/cost-management-operator/overlays/aggregate/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../base/operator
-  - ../../base/instance
+resources:
+- ../../base/operator
+- ../../base/instance

--- a/cost-management-operator/overlays/example/kustomization.yaml
+++ b/cost-management-operator/overlays/example/kustomization.yaml
@@ -2,12 +2,12 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 resources:
-  - ../aggregate
+- ../aggregate
 
-patchesJson6902:
-  - path: patch-source-and-name.yaml
-    target:
-      group: costmanagement-metrics-cfg.openshift.io
-      kind: CostManagementMetricsConfig
-      name: instance
-      version: v1beta1
+patches:
+- path: patch-source-and-name.yaml
+  target:
+    group: costmanagement-metrics-cfg.openshift.io
+    kind: CostManagementMetricsConfig
+    name: instance
+    version: v1beta1

--- a/crunchy-postgres/operator/base/kustomization.yaml
+++ b/crunchy-postgres/operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - crunchy-operator-subscription.yaml
+- crunchy-operator-subscription.yaml

--- a/crunchy-postgres/operator/overlays/v5/kustomization.yaml
+++ b/crunchy-postgres/operator/overlays/v5/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    version: v1alpha1
+resources:
+- ../../base

--- a/elasticsearch-operator/base/kustomization.yaml
+++ b/elasticsearch-operator/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: openshift-operators-redhat
 
 resources:
-  - namespace.yaml
-  - elasticsearch-subscription.yaml
-  - elasticsearch-operatorgroup.yaml
+- namespace.yaml
+- elasticsearch-subscription.yaml
+- elasticsearch-operatorgroup.yaml

--- a/elasticsearch-operator/overlays/4.6/kustomization.yaml
+++ b/elasticsearch-operator/overlays/4.6/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/elasticsearch-operator/overlays/5.0/kustomization.yaml
+++ b/elasticsearch-operator/overlays/5.0/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/elasticsearch-operator/overlays/stable-5.1/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.1/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/elasticsearch-operator/overlays/stable-5.2/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.2/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/elasticsearch-operator/overlays/stable-5.3/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.3/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/elasticsearch-operator/overlays/stable-5.4/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.4/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/elasticsearch-operator/overlays/stable-5.5/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable-5.5/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/elasticsearch-operator/overlays/stable/kustomization.yaml
+++ b/elasticsearch-operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: elasticsearch-operator
-      namespace: openshift-operators-redhat
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+    version: v1alpha1

--- a/external-secrets-operator/instance/base/kustomization.yaml
+++ b/external-secrets-operator/instance/base/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: external-secrets
 
 resources:
-  - namespace.yaml
-  - default-operatorconfig.yaml
+- namespace.yaml
+- default-operatorconfig.yaml

--- a/external-secrets-operator/instance/overlays/default/kustomization.yaml
+++ b/external-secrets-operator/instance/overlays/default/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 namespace: external-secrets
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/external-secrets-operator/operator/base/kustomization.yaml
+++ b/external-secrets-operator/operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 resources:
-  - external-secrets-subscription.yaml
+- external-secrets-subscription.yaml

--- a/external-secrets-operator/operator/overlays/alpha/kustomization.yaml
+++ b/external-secrets-operator/operator/overlays/alpha/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: external-secrets-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'alpha'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'alpha'
+  target:
+    kind: Subscription
+    name: external-secrets-operator
+resources:
+- ../../base

--- a/external-secrets-operator/operator/overlays/stable/kustomization.yaml
+++ b/external-secrets-operator/operator/overlays/stable/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: external-secrets-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable'
+  target:
+    kind: Subscription
+    name: external-secrets-operator
+resources:
+- ../../base

--- a/file-integrity-operator/instance/overlays/worker/kustomization.yaml
+++ b/file-integrity-operator/instance/overlays/worker/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-file-integrity
 
 commonAnnotations:
-  argocd.argoproj.io/sync-wave: "1"
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  argocd.argoproj.io/sync-wave: "1"
 
 resources:
-  - worker-fileintegrity.yaml
+- worker-fileintegrity.yaml

--- a/file-integrity-operator/operator/base/kustomization.yaml
+++ b/file-integrity-operator/operator/base/kustomization.yaml
@@ -7,15 +7,15 @@ commonAnnotations:
   argocd.argoproj.io/sync-wave: "0"
 
 resources:
-  - namespace.yaml
-  - file-integrity-operator-subscription.yaml
-  - file-integrity-operator-operatorgroup.yaml
+- namespace.yaml
+- file-integrity-operator-subscription.yaml
+- file-integrity-operator-operatorgroup.yaml
 
 patches:
-  - target:
-      kind: Subscription
-      name: file-integrity-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-0.1'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-0.1'
+  target:
+    kind: Subscription
+    name: file-integrity-operator

--- a/file-integrity-operator/operator/overlays/release-0.1/kustomization.yaml
+++ b/file-integrity-operator/operator/overlays/release-0.1/kustomization.yaml
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: openshift-file-integrity
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: file-integrity-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'release-0.1'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'release-0.1'
+  target:
+    kind: Subscription
+    name: file-integrity-operator
+resources:
+- ../../base

--- a/gatekeeper-operator/base/instance/kustomization.yaml
+++ b/gatekeeper-operator/base/instance/kustomization.yaml
@@ -7,4 +7,4 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - gatekeeper.yaml
+- gatekeeper.yaml

--- a/gatekeeper-operator/base/operator/kustomization.yaml
+++ b/gatekeeper-operator/base/operator/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: openshift-gatekeeper-operator
 
 resources:
-  - namespace.yaml
-  - gatekeeper-subscription.yaml
-  - gatekeeper-operatorgroup.yaml
-  - gatekeeper-catalogsource.yaml
+- namespace.yaml
+- gatekeeper-subscription.yaml
+- gatekeeper-operatorgroup.yaml
+- gatekeeper-catalogsource.yaml

--- a/gatekeeper-operator/overlays/upstream/kustomization.yaml
+++ b/gatekeeper-operator/overlays/upstream/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../base/operator
-  - ../../base/instance
+resources:
+- ../../base/operator
+- ../../base/instance

--- a/grafana-operator/base/instance/kustomization.yaml
+++ b/grafana-operator/base/instance/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - session-secret.yaml
-  - grafana-proxy-rbac.yaml
-  - grafana.yaml
+- session-secret.yaml
+- grafana-proxy-rbac.yaml
+- grafana.yaml

--- a/grafana-operator/base/operator/kustomization.yaml
+++ b/grafana-operator/base/operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - grafana-subscription.yaml
+- grafana-subscription.yaml

--- a/grafana-operator/overlays/aggregate/kustomization.yaml
+++ b/grafana-operator/overlays/aggregate/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../base/operator
-  - ../../base/instance
+resources:
+- ../../base/operator
+- ../../base/instance

--- a/grafana-operator/overlays/example/kustomization.yaml
+++ b/grafana-operator/overlays/example/kustomization.yaml
@@ -3,9 +3,8 @@ kind: Kustomization
 
 namespace: grafana
 
-bases:
-  - ../aggregate
 
 resources:
-  - namespace.yaml
-  - operator-group.yaml
+- namespace.yaml
+- operator-group.yaml
+- ../aggregate

--- a/grafana-operator/overlays/user-app-example/kustomization.yaml
+++ b/grafana-operator/overlays/user-app-example/kustomization.yaml
@@ -7,20 +7,20 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - namespace.yaml
-  - operator-group.yaml
-  - ../user-app
+- namespace.yaml
+- operator-group.yaml
+- ../user-app
 
-patchesJson6902:
-  - target:
-      version: v1alpha1
-      group: integreatly.org
-      kind: Grafana
-      name: grafana
-    path: patch-grafana-sar.yaml
-  - target:
-      version: v1
-      group: rbac.authorization.k8s.io
-      kind: ClusterRoleBinding
-      name: cluster-monitoring-view
-    path: patch-cluster-monitoring-view.yaml
+patches:
+- path: patch-grafana-sar.yaml
+  target:
+    group: integreatly.org
+    kind: Grafana
+    name: grafana
+    version: v1alpha1
+- path: patch-cluster-monitoring-view.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRoleBinding
+    name: cluster-monitoring-view
+    version: v1

--- a/grafana-operator/overlays/user-app/kustomization.yaml
+++ b/grafana-operator/overlays/user-app/kustomization.yaml
@@ -4,26 +4,25 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../base/operator
-  - ../../base/instance
 
 resources:
-  - grafana-ds.yaml
-  - cluster-monitor-view-rb.yaml
-  - grafana-auth-secret.yaml
+- grafana-ds.yaml
+- cluster-monitor-view-rb.yaml
+- grafana-auth-secret.yaml
+- ../../base/operator
+- ../../base/instance
 
 patches:
-  - target:
-      kind: Grafana
-      name: grafana
-    patch: |-
-      - op: add
-        path: /spec/deployment
-        value:
-          env:
-          - name: GRAFANA_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: grafana-auth-secret
-                key: token
+- patch: |-
+    - op: add
+      path: /spec/deployment
+      value:
+        env:
+        - name: GRAFANA_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: grafana-auth-secret
+              key: token
+  target:
+    kind: Grafana
+    name: grafana

--- a/groups-roles-bindings/base/kustomization.yaml
+++ b/groups-roles-bindings/base/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 # Default groups and user config.
 resources:
-  - argocdadmins-group-base.yaml
-  - developer-group-base.yaml
-  - cluster-admin-users-rolebinding.yaml
+- argocdadmins-group-base.yaml
+- developer-group-base.yaml
+- cluster-admin-users-rolebinding.yaml

--- a/installplan-approver/base/kustomization.yaml
+++ b/installplan-approver/base/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - serviceaccount.yaml
-  - rbac.yaml
-  - installplan-approver-job.yaml
+- serviceaccount.yaml
+- rbac.yaml
+- installplan-approver-job.yaml

--- a/jaeger-operator/base/kustomization.yaml
+++ b/jaeger-operator/base/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: openshift-distributed-tracing
 
 resources:
-  - jaeger-subscription.yaml
-  - operatorgroup.yaml
+- jaeger-subscription.yaml
+- operatorgroup.yaml

--- a/jaeger-operator/overlays/default/kustomization.yaml
+++ b/jaeger-operator/overlays/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../../elasticsearch-operator/base
-  - ../../base
+resources:
+- ../../../elasticsearch-operator/base
+- ../../base

--- a/jaeger-operator/overlays/stable/kustomization.yaml
+++ b/jaeger-operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: jaeger-product
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: jaeger-product
+    namespace: openshift-operators
+    version: v1alpha1

--- a/jaeger-operator/overlays/tech-preview/kustomization.yaml
+++ b/jaeger-operator/overlays/tech-preview/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: jaeger-product
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: jaeger-product
+    namespace: openshift-operators
+    version: v1alpha1

--- a/jenkins2/base/kustomization.yaml
+++ b/jenkins2/base/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - jenkins-dc.yaml
-  - jenkins-jnlp.yaml
-  - jenkins-pvc.yaml
-  - jenkins-rolebinding.yaml
-  - jenkins-route.yaml
-  - jenkins-sa.yaml
-  - jenkins-svc.yaml
+- jenkins-dc.yaml
+- jenkins-jnlp.yaml
+- jenkins-pvc.yaml
+- jenkins-rolebinding.yaml
+- jenkins-route.yaml
+- jenkins-sa.yaml
+- jenkins-svc.yaml

--- a/jenkins2/overlays/default/kustomization.yaml
+++ b/jenkins2/overlays/default/kustomization.yaml
@@ -2,5 +2,5 @@
 # Point to this directory in the "bases" field.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/jenkins2/overlays/m2-pvc-nexus2-sonarqube8-settings/kustomization.yaml
+++ b/jenkins2/overlays/m2-pvc-nexus2-sonarqube8-settings/kustomization.yaml
@@ -2,20 +2,19 @@
 # Point to this directory in the "bases" field.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
 resources:
-  - jenkins-cm.yaml
-  - maven-m2-pvc.yaml
-  - nexus-secret.yaml
+- jenkins-cm.yaml
+- maven-m2-pvc.yaml
+- nexus-secret.yaml
+- ../../base
 generatorOptions:
+  disableNameSuffixHash: true
   labels:
     app: jenkins
     app.kubernetes.io/component: maven-settings-cm
     app.kubernetes.io/instance: jenkins
     app.kubernetes.io/part-of: jenkins
-  disableNameSuffixHash: true
 configMapGenerator:
-  - name: maven-settings-cm
-    files:
-      - settings.xml
+- files:
+  - settings.xml
+  name: maven-settings-cm

--- a/jenkins2/overlays/m2-pvc/kustomization.yaml
+++ b/jenkins2/overlays/m2-pvc/kustomization.yaml
@@ -2,19 +2,18 @@
 # Point to this directory in the "bases" field.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
 resources:
-  - jenkins-cm.yaml
-  - maven-m2-pvc.yaml
+- jenkins-cm.yaml
+- maven-m2-pvc.yaml
+- ../../base
 generatorOptions:
+  disableNameSuffixHash: true
   labels:
     app: jenkins
     app.kubernetes.io/component: maven-settings-cm
     app.kubernetes.io/instance: jenkins
     app.kubernetes.io/part-of: jenkins
-  disableNameSuffixHash: true
 configMapGenerator:
-  - name: maven-settings-cm
-    files:
-      - settings.xml
+- files:
+  - settings.xml
+  name: maven-settings-cm

--- a/jenkins2/overlays/nexus2-settings/kustomization.yaml
+++ b/jenkins2/overlays/nexus2-settings/kustomization.yaml
@@ -2,19 +2,18 @@
 # Point to this directory in the "bases" field.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
 resources:
-  - jenkins-cm.yaml
-  - nexus-secret.yaml
+- jenkins-cm.yaml
+- nexus-secret.yaml
+- ../../base
 generatorOptions:
+  disableNameSuffixHash: true
   labels:
     app: jenkins
     app.kubernetes.io/component: maven-settings-cm
     app.kubernetes.io/instance: jenkins
     app.kubernetes.io/part-of: jenkins
-  disableNameSuffixHash: true
 configMapGenerator:
-  - name: maven-settings-cm
-    files:
-      - settings.xml
+- files:
+  - settings.xml
+  name: maven-settings-cm

--- a/kiali-operator/base/kustomization.yaml
+++ b/kiali-operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - kiali-operator-subscription.yaml
+- kiali-operator-subscription.yaml

--- a/kiali-operator/overlays/stable/kustomization.yaml
+++ b/kiali-operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: kiali-ossm
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: kiali-ossm
+    namespace: openshift-operators
+    version: v1alpha1

--- a/kyverno/base/kustomization.yaml
+++ b/kyverno/base/kustomization.yaml
@@ -2,26 +2,26 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/kyverno/kyverno/release-1.6/config/release/install.yaml
+- https://raw.githubusercontent.com/kyverno/kyverno/release-1.6/config/release/install.yaml
 
 patches:
-  - patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 768Mi
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: '--clientRateLimitQPS=350'
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: '--clientRateLimitBurst=350'
-    target:
-      kind: Deployment
-      name: kyverno
-  - patch: |-
-      - op: replace
-        path: /data/resourceFilters
-        value: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][*,openshift,*][*,openshift-*,*][*,open-cluster-*,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]'
-    target:
-      kind: ConfigMap
-      name: kyverno
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/limits/memory
+      value: 768Mi
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: '--clientRateLimitQPS=350'
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: '--clientRateLimitBurst=350'
+  target:
+    kind: Deployment
+    name: kyverno
+- patch: |-
+    - op: replace
+      path: /data/resourceFilters
+      value: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][*,openshift,*][*,openshift-*,*][*,open-cluster-*,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]'
+  target:
+    kind: ConfigMap
+    name: kyverno

--- a/kyverno/overlays/sample-policies/kustomization.yaml
+++ b/kyverno/overlays/sample-policies/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - validate-probes-policy.yaml
-  - require-requests-limits-policy.yaml
-  - disallow-anyuid-scc-policy.yaml
+- validate-probes-policy.yaml
+- require-requests-limits-policy.yaml
+- disallow-anyuid-scc-policy.yaml

--- a/letsencrypt-certs/base/kustomization.yaml
+++ b/letsencrypt-certs/base/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: letsencrypt-job
 
 # Job resources.
 resources:
-  - namespace.yaml
-  - job-serviceaccount.yaml
-  - rbac.yaml
-  - job.yaml
+- namespace.yaml
+- job-serviceaccount.yaml
+- rbac.yaml
+- job.yaml

--- a/local-storage/operator/base/kustomization.yaml
+++ b/local-storage/operator/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: openshift-local-storage
 
 resources:
-  - namespace.yaml
-  - operator-group.yaml
-  - subscription.yaml
+- namespace.yaml
+- operator-group.yaml
+- subscription.yaml

--- a/local-storage/operator/overlays/stable/kustomization.yaml
+++ b/local-storage/operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: local-storage-operator
-      namespace: openshift-local-storage
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: local-storage-operator
+    namespace: openshift-local-storage
+    version: v1alpha1
+resources:
+- ../../base

--- a/migration-toolkit-apps/base/kustomization.yaml
+++ b/migration-toolkit-apps/base/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: app-migration
 resources:
-  - mta-web-console-dc.yaml
-  - mta-web-console-executor-dc.yaml
-  - mta-web-console-executor-svc.yaml
-  - mta-web-console-mta-web-claim-pvc.yaml
-  - mta-web-console-postgresql-claim-pvc.yaml
-  - mta-web-console-postgresql-dc.yaml
-  - mta-web-console-postgresql-svc.yaml
-  - mta-web-console-svc.yaml
-  - secure-mta-web-console-route.yaml
+- mta-web-console-dc.yaml
+- mta-web-console-executor-dc.yaml
+- mta-web-console-executor-svc.yaml
+- mta-web-console-mta-web-claim-pvc.yaml
+- mta-web-console-postgresql-claim-pvc.yaml
+- mta-web-console-postgresql-dc.yaml
+- mta-web-console-postgresql-svc.yaml
+- mta-web-console-svc.yaml
+- secure-mta-web-console-route.yaml

--- a/namespace-configuration-operator/base/kustomization.yaml
+++ b/namespace-configuration-operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - subscription.yaml
+- subscription.yaml

--- a/namespace-configuration-operator/overlays/default/kustomization.yaml
+++ b/namespace-configuration-operator/overlays/default/kustomization.yaml
@@ -3,10 +3,9 @@ kind: Kustomization
 
 namespace: namespace-configuration-operator
 
-bases:
-  - ../../base
-  - ../../../installplan-approver/base
 
 resources:
-  - namespace.yaml
-  - operator-group.yaml
+- namespace.yaml
+- operator-group.yaml
+- ../../base
+- ../../../installplan-approver/base

--- a/nexus2/base/kustomization.yaml
+++ b/nexus2/base/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - nexus-pvc.yaml
-  - nexus-svc.yaml
-  - nexus-route.yaml
-  - nexus-deployment.yaml
-  - configure-nexus-job.yaml
+- nexus-pvc.yaml
+- nexus-svc.yaml
+- nexus-route.yaml
+- nexus-deployment.yaml
+- configure-nexus-job.yaml

--- a/nmstate/instance/kustomization.yaml
+++ b/nmstate/instance/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - nmstate-nmstate.yaml
+- nmstate-nmstate.yaml

--- a/nmstate/operator/kustomization.yaml
+++ b/nmstate/operator/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - openshift-nmstate-ns.yaml
-  - openshift-nmstate-og.yaml
-  - kubernetes-nmstate-operator-sub.yaml
+- openshift-nmstate-ns.yaml
+- openshift-nmstate-og.yaml
+- kubernetes-nmstate-operator-sub.yaml

--- a/oauth/base/kustomization.yaml
+++ b/oauth/base/kustomization.yaml
@@ -1,4 +1,4 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
-  - oauth-cluster.yaml
+- oauth-cluster.yaml

--- a/oauth/overlays/htpass-idp/kustomization.yaml
+++ b/oauth/overlays/htpass-idp/kustomization.yaml
@@ -1,13 +1,13 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
-bases:
-  - ../htpass
 
-patchesJson6902:
-  - target:
-      group: config.openshift.io
-      version: v1
-      kind: OAuth
-      name: cluster
-    path: oauth-idp-patch.yaml
+resources:
+- ../htpass
+patches:
+- path: oauth-idp-patch.yaml
+  target:
+    group: config.openshift.io
+    kind: OAuth
+    name: cluster
+    version: v1

--- a/oauth/overlays/htpass/kustomization.yaml
+++ b/oauth/overlays/htpass/kustomization.yaml
@@ -1,27 +1,27 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
-bases:
-  - ../../base
-  - cluster-admin-role.yaml
 
 generatorOptions:
-  disableNameSuffixHash: true
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
     argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  disableNameSuffixHash: true
 
 secretGenerator:
-  - name: htpass-secret
-    namespace: openshift-config
-    files:
-      - htpasswd=files/users.htpasswd
-    type: Opaque
+- files:
+  - htpasswd=files/users.htpasswd
+  name: htpass-secret
+  namespace: openshift-config
+  type: Opaque
 
-patchesJson6902:
-  - target:
-      group: config.openshift.io
-      version: v1
-      kind: OAuth
-      name: cluster
-    path: oauth-htpass-patch.yaml
+resources:
+- ../../base
+- cluster-admin-role.yaml
+patches:
+- path: oauth-htpass-patch.yaml
+  target:
+    group: config.openshift.io
+    kind: OAuth
+    name: cluster
+    version: v1

--- a/oauth/overlays/ldap/kustomization.yaml
+++ b/oauth/overlays/ldap/kustomization.yaml
@@ -1,19 +1,19 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
-bases:
-  - ../../base
 
 generatorOptions:
-  disableNameSuffixHash: true
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
     argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  disableNameSuffixHash: true
 
-patchesJson6902:
-  - target:
-      group: config.openshift.io
-      version: v1
-      kind: OAuth
-      name: cluster
-    path: oauth-ldap-patch.yaml
+resources:
+- ../../base
+patches:
+- path: oauth-ldap-patch.yaml
+  target:
+    group: config.openshift.io
+    kind: OAuth
+    name: cluster
+    version: v1

--- a/opendatahub-operator/operator/base/kustomization.yaml
+++ b/opendatahub-operator/operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - opendatahub-operator-subscription.yaml
+- opendatahub-operator-subscription.yaml

--- a/opendatahub-operator/operator/overlays/rolling/kustomization.yaml
+++ b/opendatahub-operator/operator/overlays/rolling/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: opendatahub-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: opendatahub-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/opendatahub-operator/operator/overlays/stable/kustomization.yaml
+++ b/opendatahub-operator/operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: opendatahub-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: opendatahub-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-api-for-data-protection-operator/base/kustomization.yaml
+++ b/openshift-api-for-data-protection-operator/base/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - operatorgroup.yaml
-  - subscription.yaml
+- namespace.yaml
+- operatorgroup.yaml
+- subscription.yaml

--- a/openshift-api-for-data-protection-operator/overlays/stable/kustomization.yaml
+++ b/openshift-api-for-data-protection-operator/overlays/stable/kustomization.yaml
@@ -1,18 +1,17 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: redhat-oadp-operator
-      namespace: openshift-adp
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable'
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: redhat-oadp-operator
+    namespace: openshift-adp
+    version: v1alpha1
+resources:
+- ../../base

--- a/openshift-container-storage-noobaa/base/kustomization.yaml
+++ b/openshift-container-storage-noobaa/base/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - noobaa.yaml
-  - backingstore.yaml
-  - bucketclass.yaml
+- noobaa.yaml
+- backingstore.yaml
+- bucketclass.yaml

--- a/openshift-container-storage-noobaa/overlays/default/kustomization.yaml
+++ b/openshift-container-storage-noobaa/overlays/default/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: noobaa.io
-      version: v1alpha1
-      kind: BackingStore
-      name: mcg-pv-pool-bs
-      namespace: openshift-storage
-    path: patch-storage-capacity.yaml
+resources:
+- ../../base
+patches:
+- path: patch-storage-capacity.yaml
+  target:
+    group: noobaa.io
+    kind: BackingStore
+    name: mcg-pv-pool-bs
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-container-storage-operator/operator/base/kustomization.yaml
+++ b/openshift-container-storage-operator/operator/base/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - namespace.yaml
-  - openshift-container-storage-operator-subscription.yaml
-  - openshift-container-storage-operator-operatorgroup.yaml
+- namespace.yaml
+- openshift-container-storage-operator-subscription.yaml
+- openshift-container-storage-operator-operatorgroup.yaml

--- a/openshift-container-storage-operator/operator/overlays/eus-4.6/kustomization.yaml
+++ b/openshift-container-storage-operator/operator/overlays/eus-4.6/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ocs-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ocs-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-container-storage-operator/operator/overlays/stable-4.6/kustomization.yaml
+++ b/openshift-container-storage-operator/operator/overlays/stable-4.6/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ocs-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ocs-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-container-storage-operator/operator/overlays/stable-4.7/kustomization.yaml
+++ b/openshift-container-storage-operator/operator/overlays/stable-4.7/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ocs-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ocs-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-container-storage-operator/operator/overlays/stable-4.8/kustomization.yaml
+++ b/openshift-container-storage-operator/operator/overlays/stable-4.8/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: ocs-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: ocs-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-data-foundation-operator/aggregate/overlays/aws-node-labeler/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/aws-node-labeler/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../../operator/overlays/stable-4.9
-  - ../../../instance/overlays/aws
-  - ../../../config-helpers/node-labeler/overlays/default
+resources:
+- ../../../operator/overlays/stable-4.9
+- ../../../instance/overlays/aws
+- ../../../config-helpers/node-labeler/overlays/default

--- a/openshift-data-foundation-operator/aggregate/overlays/aws/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/aws/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../../operator/overlays/stable-4.9
-  - ../../../instance/overlays/aws
+resources:
+- ../../../operator/overlays/stable-4.9
+- ../../../instance/overlays/aws

--- a/openshift-data-foundation-operator/aggregate/overlays/vsphere-node-labeler/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/vsphere-node-labeler/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../../operator/overlays/stable-4.9
-  - ../../../instance/overlays/vsphere
-  - ../../../config-helpers/node-labeler/overlays/default
+resources:
+- ../../../operator/overlays/stable-4.9
+- ../../../instance/overlays/vsphere
+- ../../../config-helpers/node-labeler/overlays/default

--- a/openshift-data-foundation-operator/aggregate/overlays/vsphere/kustomization.yaml
+++ b/openshift-data-foundation-operator/aggregate/overlays/vsphere/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../../operator/overlays/stable-4.9
-  - ../../../instance/overlays/vsphere
+resources:
+- ../../../operator/overlays/stable-4.9
+- ../../../instance/overlays/vsphere

--- a/openshift-data-foundation-operator/config-helpers/node-labeler/base/kustomization.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: openshift-storage
 
 resources:
-  - node-label-job.yaml
-  - rbac.yaml
-  - service-account.yaml
+- node-label-job.yaml
+- rbac.yaml
+- service-account.yaml

--- a/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default/kustomization.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/openshift-data-foundation-operator/instance/base/kustomization.yaml
+++ b/openshift-data-foundation-operator/instance/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-storage
 
 resources:
-  - storagesystem.yaml
+- storagesystem.yaml

--- a/openshift-data-foundation-operator/instance/overlays/aws/kustomization.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/aws/kustomization.yaml
@@ -3,9 +3,8 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
 resources:
-  - ocsinitialization.yaml
-  - storagecluster.yaml
+- ocsinitialization.yaml
+- storagecluster.yaml
+- ../../base

--- a/openshift-data-foundation-operator/instance/overlays/vsphere/kustomization.yaml
+++ b/openshift-data-foundation-operator/instance/overlays/vsphere/kustomization.yaml
@@ -3,9 +3,8 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
 resources:
-  - ocsinitialization.yaml
-  - storagecluster.yaml
+- ocsinitialization.yaml
+- storagecluster.yaml
+- ../../base

--- a/openshift-data-foundation-operator/operator/base/kustomization.yaml
+++ b/openshift-data-foundation-operator/operator/base/kustomization.yaml
@@ -4,10 +4,10 @@ kind: Kustomization
 namespace: openshift-storage
 
 resources:
-  - enable-console-plugin-job.yaml
-  - enable-console-plugin-rbac.yaml
-  - enable-console-plugin-sa.yaml
-  - openshift-data-foundation-console-plugin.yaml
-  - openshift-data-foundation-operator-subscription.yaml
-  - openshift-data-foundation-operator-operatorgroup.yaml
-  - openshift-storage-namespace.yaml
+- enable-console-plugin-job.yaml
+- enable-console-plugin-rbac.yaml
+- enable-console-plugin-sa.yaml
+- openshift-data-foundation-console-plugin.yaml
+- openshift-data-foundation-operator-subscription.yaml
+- openshift-data-foundation-operator-operatorgroup.yaml
+- openshift-storage-namespace.yaml

--- a/openshift-data-foundation-operator/operator/overlays/stable-4.10/kustomization.yaml
+++ b/openshift-data-foundation-operator/operator/overlays/stable-4.10/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: odf-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: odf-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-data-foundation-operator/operator/overlays/stable-4.11/kustomization.yaml
+++ b/openshift-data-foundation-operator/operator/overlays/stable-4.11/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: odf-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: odf-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-data-foundation-operator/operator/overlays/stable-4.12/kustomization.yaml
+++ b/openshift-data-foundation-operator/operator/overlays/stable-4.12/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: odf-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: odf-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-data-foundation-operator/operator/overlays/stable-4.9/kustomization.yaml
+++ b/openshift-data-foundation-operator/operator/overlays/stable-4.9/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-storage
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: odf-operator
-      namespace: openshift-storage
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: odf-operator
+    namespace: openshift-storage
+    version: v1alpha1

--- a/openshift-dev-spaces/instance/base/kustomization.yaml
+++ b/openshift-dev-spaces/instance/base/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - checluster.yaml
+- namespace.yaml
+- checluster.yaml

--- a/openshift-dev-spaces/instance/overlays/default/kustomization.yaml
+++ b/openshift-dev-spaces/instance/overlays/default/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/openshift-dev-spaces/operator/base/kustomization.yaml
+++ b/openshift-dev-spaces/operator/base/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - subscription.yaml
+- subscription.yaml

--- a/openshift-dev-spaces/operator/overlays/stable/kustomization.yaml
+++ b/openshift-dev-spaces/operator/overlays/stable/kustomization.yaml
@@ -1,18 +1,17 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: devspaces
-      namespace: openshift-operators
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable'
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: devspaces
+    namespace: openshift-operators
+    version: v1alpha1
+resources:
+- ../../base

--- a/openshift-gitops-operator/base/kustomization.yaml
+++ b/openshift-gitops-operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - openshift-gitops-operator-subscription.yaml
+- openshift-gitops-operator-subscription.yaml

--- a/openshift-gitops-operator/overlays/gitops-1.5/kustomization.yaml
+++ b/openshift-gitops-operator/overlays/gitops-1.5/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-gitops-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-gitops-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-gitops-operator/overlays/gitops-1.6/kustomization.yaml
+++ b/openshift-gitops-operator/overlays/gitops-1.6/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-gitops-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-gitops-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-gitops-operator/overlays/gitops-1.7/kustomization.yaml
+++ b/openshift-gitops-operator/overlays/gitops-1.7/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-gitops-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-gitops-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-gitops-operator/overlays/latest/kustomization.yaml
+++ b/openshift-gitops-operator/overlays/latest/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-gitops-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-gitops-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-gitops-operator/overlays/preview/kustomization.yaml
+++ b/openshift-gitops-operator/overlays/preview/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-gitops-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-gitops-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-gitops-operator/overlays/stable/kustomization.yaml
+++ b/openshift-gitops-operator/overlays/stable/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-gitops-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-gitops-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-image-registry/base/kustomization.yaml
+++ b/openshift-image-registry/base/kustomization.yaml
@@ -1,7 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - image-registry-config.yaml
-  - image-registry-pvc.yaml
+- image-registry-config.yaml
+- image-registry-pvc.yaml

--- a/openshift-image-registry/overlays/vsphere/kustomization.yaml
+++ b/openshift-image-registry/overlays/vsphere/kustomization.yaml
@@ -1,31 +1,30 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: PersistentVolumeClaim
-      name: image-registry-storage
-    patch: |-
-      - op: replace
-        path: /spec/resources/requests/storage
-        value: '5Gi'
-      - op: replace
-        path: /spec/accessModes
-        value:
-          - ReadWriteOnce
-  - target:
-      kind: Config
-      name: cluster
-    patch: |-
-      - op: add
-        path: /spec/storage
-        value:
-          pvc:
-            claim: 'image-registry-storage'
-      - op: replace
-        path: /spec/rolloutStrategy
-        value: 'Recreate'
+- patch: |-
+    - op: replace
+      path: /spec/resources/requests/storage
+      value: '5Gi'
+    - op: replace
+      path: /spec/accessModes
+      value:
+        - ReadWriteOnce
+  target:
+    kind: PersistentVolumeClaim
+    name: image-registry-storage
+- patch: |-
+    - op: add
+      path: /spec/storage
+      value:
+        pvc:
+          claim: 'image-registry-storage'
+    - op: replace
+      path: /spec/rolloutStrategy
+      value: 'Recreate'
+  target:
+    kind: Config
+    name: cluster
+resources:
+- ../../base

--- a/openshift-logging/instance/base/kustomization.yaml
+++ b/openshift-logging/instance/base/kustomization.yaml
@@ -1,8 +1,7 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - cluster-logging.yaml
-  - cluster-log-fowarder.yaml
-  - console-link.yaml
+- cluster-logging.yaml
+- cluster-log-fowarder.yaml
+- console-link.yaml

--- a/openshift-logging/instance/overlays/default/kustomization.yaml
+++ b/openshift-logging/instance/overlays/default/kustomization.yaml
@@ -1,22 +1,21 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: ClusterLogging
-      name: instance
-    patch: |-
-      - op: replace
-        path: /spec/logStore/elasticsearch/storage/storageClassName
-        value: 'gp2'
-  - target:
-      kind: ConsoleLink
-      name: kibana-public-url
-    patch: |-
-      - op: replace
-        path: /spec/href
-        value: 'https://kibana-openshift-logging.apps.mgnt.adetalhouet.rhtelco.io'
+- patch: |-
+    - op: replace
+      path: /spec/logStore/elasticsearch/storage/storageClassName
+      value: 'gp2'
+  target:
+    kind: ClusterLogging
+    name: instance
+- patch: |-
+    - op: replace
+      path: /spec/href
+      value: 'https://kibana-openshift-logging.apps.mgnt.adetalhouet.rhtelco.io'
+  target:
+    kind: ConsoleLink
+    name: kibana-public-url
+resources:
+- ../../base

--- a/openshift-logging/operator/base/kustomization.yaml
+++ b/openshift-logging/operator/base/kustomization.yaml
@@ -1,10 +1,9 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: openshift-logging
 
 resources:
-  - openshift-logging-namespace.yaml
-  - openshift-logging-operatorgroup.yaml
-  - openshift-logging-subscription.yaml
+- openshift-logging-namespace.yaml
+- openshift-logging-operatorgroup.yaml
+- openshift-logging-subscription.yaml

--- a/openshift-logging/operator/overlays/stable/kustomization.yaml
+++ b/openshift-logging/operator/overlays/stable/kustomization.yaml
@@ -1,18 +1,17 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: cluster-logging
-      namespace: openshift-logging
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable'
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: cluster-logging
+    namespace: openshift-logging
+    version: v1alpha1
+resources:
+- ../../base

--- a/openshift-nfd-operator/aggregate/overlays/default/kustomization.yaml
+++ b/openshift-nfd-operator/aggregate/overlays/default/kustomization.yaml
@@ -7,5 +7,5 @@ commonAnnotations:
 namespace: openshift-nfd
 
 resources:
-  - ../../../operator/overlays/stable
-  - ../../../instance/overlays/default
+- ../../../operator/overlays/stable
+- ../../../instance/overlays/default

--- a/openshift-nfd-operator/instance/base/kustomization.yaml
+++ b/openshift-nfd-operator/instance/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-nfd
 
 resources:
-  - node-feature-discovery.yaml
+- node-feature-discovery.yaml

--- a/openshift-nfd-operator/instance/overlays/default/kustomization.yaml
+++ b/openshift-nfd-operator/instance/overlays/default/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/openshift-nfd-operator/operator/base/kustomization.yaml
+++ b/openshift-nfd-operator/operator/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: openshift-nfd
 
 resources:
-  - nfd-namespace.yaml
-  - nfd-operatorgroup.yaml
-  - nfd-subscription.yaml
+- nfd-namespace.yaml
+- nfd-operatorgroup.yaml
+- nfd-subscription.yaml

--- a/openshift-nfd-operator/operator/overlays/stable/kustomization.yaml
+++ b/openshift-nfd-operator/operator/overlays/stable/kustomization.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: nfd
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    kind: Subscription
+    name: nfd
+resources:
+- ../../base

--- a/openshift-pipelines-operator/base/kustomization.yaml
+++ b/openshift-pipelines-operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - openshift-pipelines-operator-subscription.yaml
+- openshift-pipelines-operator-subscription.yaml

--- a/openshift-pipelines-operator/overlays/latest/kustomization.yaml
+++ b/openshift-pipelines-operator/overlays/latest/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-pipelines-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-pipelines-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-pipelines-operator/overlays/pipelines-1.7/kustomization.yaml
+++ b/openshift-pipelines-operator/overlays/pipelines-1.7/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-pipelines-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-pipelines-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-pipelines-operator/overlays/pipelines-1.8/kustomization.yaml
+++ b/openshift-pipelines-operator/overlays/pipelines-1.8/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-pipelines-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-pipelines-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-pipelines-operator/overlays/pipelines-1.9/kustomization.yaml
+++ b/openshift-pipelines-operator/overlays/pipelines-1.9/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-pipelines-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-pipelines-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-pipelines-operator/overlays/preview/kustomization.yaml
+++ b/openshift-pipelines-operator/overlays/preview/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-pipelines-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-pipelines-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-pipelines-operator/overlays/stable/kustomization.yaml
+++ b/openshift-pipelines-operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-pipelines-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-pipelines-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-pipelines-tasks/dotnet/5.0/kustomization.yaml
+++ b/openshift-pipelines-tasks/dotnet/5.0/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - dotnet-cli-task.yaml
+- dotnet-cli-task.yaml

--- a/openshift-pipelines-tasks/maven/base/kustomization.yaml
+++ b/openshift-pipelines-tasks/maven/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - maven-task.yaml
+- maven-task.yaml

--- a/openshift-pipelines-tasks/maven/overlays/m2-cache/kustomization.yaml
+++ b/openshift-pipelines-tasks/maven/overlays/m2-cache/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - path: patch-m2-cache.yaml
-    target:
-      group: tekton.dev
-      kind: Task
-      name: maven
-      version: v1beta1
+resources:
+- ../../base
+patches:
+- path: patch-m2-cache.yaml
+  target:
+    group: tekton.dev
+    kind: Task
+    name: maven
+    version: v1beta1

--- a/openshift-pipelines-tasks/newman/base/kustomization.yaml
+++ b/openshift-pipelines-tasks/newman/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - newman-task.yaml
+- newman-task.yaml

--- a/openshift-pipelines-tasks/rollout-restart/base/kustomization.yaml
+++ b/openshift-pipelines-tasks/rollout-restart/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - rollout-restart-task.yaml
+- rollout-restart-task.yaml

--- a/openshift-pipelines-tasks/s2i-binary-build/base/kustomization.yaml
+++ b/openshift-pipelines-tasks/s2i-binary-build/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - s2i-binary-build-task.yaml
+- s2i-binary-build-task.yaml

--- a/openshift-sandboxed-containers/example-workload/base/kustomization.yaml
+++ b/openshift-sandboxed-containers/example-workload/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-sandboxed-containers-operator
 
 resources:
-  - example-deploy.yaml
+- example-deploy.yaml

--- a/openshift-sandboxed-containers/instance/base/kustomization.yaml
+++ b/openshift-sandboxed-containers/instance/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - cluster-kataconfig-kataconfig.yaml
+- cluster-kataconfig-kataconfig.yaml

--- a/openshift-sandboxed-containers/operator/base/kustomization.yaml
+++ b/openshift-sandboxed-containers/operator/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: openshift-sandboxed-containers-operator
 
 resources:
-  - openshift-sandboxed-containers-operator-ns.yaml
-  - openshift-sandboxed-containers-operator-og.yaml
-  - openshift-sandboxed-containers-operator-sub.yaml
+- openshift-sandboxed-containers-operator-ns.yaml
+- openshift-sandboxed-containers-operator-og.yaml
+- openshift-sandboxed-containers-operator-sub.yaml

--- a/openshift-sandboxed-containers/operator/overlays/preview-1.1/kustomization.yaml
+++ b/openshift-sandboxed-containers/operator/overlays/preview-1.1/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 
 namespace: openshift-sandboxed-containers-operator
 
-bases:
-  - ../../base
 
-patchesStrategicMerge:
-  - openshift-sandboxed-containers-operator-sub.yaml
+resources:
+- ../../base
+patches:
+- path: openshift-sandboxed-containers-operator-sub.yaml

--- a/openshift-sandboxed-containers/operator/overlays/stable-1.2/kustomization.yaml
+++ b/openshift-sandboxed-containers/operator/overlays/stable-1.2/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 
 namespace: openshift-sandboxed-containers-operator
 
-bases:
-  - ../../base
 
-patchesStrategicMerge:
-  - openshift-sandboxed-containers-operator-sub.yaml
+resources:
+- ../../base
+patches:
+- path: openshift-sandboxed-containers-operator-sub.yaml

--- a/openshift-serverless/instance/knative-eventing/base/kustomization.yaml
+++ b/openshift-serverless/instance/knative-eventing/base/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: knative-eventing
 
 resources:
-  - knative-eventing-instance.yaml
-  - knative-eventing-namespace.yaml
+- knative-eventing-instance.yaml
+- knative-eventing-namespace.yaml

--- a/openshift-serverless/instance/knative-eventing/overlays/default/kustomization.yaml
+++ b/openshift-serverless/instance/knative-eventing/overlays/default/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 namespace: knative-eventing
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/openshift-serverless/instance/knative-eventing/overlays/knative-kafka/kustomization.yaml
+++ b/openshift-serverless/instance/knative-eventing/overlays/knative-kafka/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: knative-eventing
 
 resources:
-  - knative-kafka.yaml
+- knative-kafka.yaml
+- ../../base
 
-bases:
-  - ../../base

--- a/openshift-serverless/instance/knative-serving/base/kustomization.yaml
+++ b/openshift-serverless/instance/knative-serving/base/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: knative-serving
 
 resources:
-  - knative-serving-instance.yaml
-  - knative-serving-namespace.yaml
+- knative-serving-instance.yaml
+- knative-serving-namespace.yaml

--- a/openshift-serverless/instance/knative-serving/overlays/default/kustomization.yaml
+++ b/openshift-serverless/instance/knative-serving/overlays/default/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 namespace: knative-serving
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/openshift-serverless/operator/base/kustomization.yaml
+++ b/openshift-serverless/operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - serverless-operator-subscription.yaml
+- serverless-operator-subscription.yaml

--- a/openshift-serverless/operator/overlays/4.5/kustomization.yaml
+++ b/openshift-serverless/operator/overlays/4.5/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: serverless-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: serverless-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-serverless/operator/overlays/4.6/kustomization.yaml
+++ b/openshift-serverless/operator/overlays/4.6/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: serverless-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: serverless-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-serverless/operator/overlays/4.7/kustomization.yaml
+++ b/openshift-serverless/operator/overlays/4.7/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: serverless-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: serverless-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-serverless/operator/overlays/stable/kustomization.yaml
+++ b/openshift-serverless/operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: serverless-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: serverless-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-servicemesh/instance/base/kustomization.yaml
+++ b/openshift-servicemesh/instance/base/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: istio-system
 
 resources:
-  - istio-system-namespace.yaml
-  - servicemesh-controlplane.yaml
+- istio-system-namespace.yaml
+- servicemesh-controlplane.yaml

--- a/openshift-servicemesh/instance/overlays/default/kustomization.yaml
+++ b/openshift-servicemesh/instance/overlays/default/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 namespace: istio-system
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/openshift-servicemesh/operator/base/kustomization.yaml
+++ b/openshift-servicemesh/operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - servicemesh-operator-subscription.yaml
+- servicemesh-operator-subscription.yaml

--- a/openshift-servicemesh/operator/overlays/1.0/kustomization.yaml
+++ b/openshift-servicemesh/operator/overlays/1.0/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: servicemeshoperator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: servicemeshoperator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-servicemesh/operator/overlays/stable/kustomization.yaml
+++ b/openshift-servicemesh/operator/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: servicemeshoperator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: servicemeshoperator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/openshift-sriov-network-operator/base/kustomization.yaml
+++ b/openshift-sriov-network-operator/base/kustomization.yaml
@@ -1,9 +1,8 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - namespace.yaml
-  - operatorgroup.yaml
-  - subscription.yaml
-  - defaultoperatorconfig.yaml
+- namespace.yaml
+- operatorgroup.yaml
+- subscription.yaml
+- defaultoperatorconfig.yaml

--- a/openshift-sriov-network-operator/overlays/4.10/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/4.10/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+- ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: sriov-network-operator-subscription
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: '4.10'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: '4.10'
+  target:
+    kind: Subscription
+    name: sriov-network-operator-subscription

--- a/openshift-sriov-network-operator/overlays/4.11/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/4.11/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+- ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: sriov-network-operator-subscription
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: '4.11'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: '4.11'
+  target:
+    kind: Subscription
+    name: sriov-network-operator-subscription

--- a/openshift-sriov-network-operator/overlays/4.12/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/4.12/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+- ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: sriov-network-operator-subscription
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: '4.12'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: '4.12'
+  target:
+    kind: Subscription
+    name: sriov-network-operator-subscription

--- a/openshift-sriov-network-operator/overlays/4.9/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/4.9/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+- ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: sriov-network-operator-subscription
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: '4.9'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: '4.9'
+  target:
+    kind: Subscription
+    name: sriov-network-operator-subscription

--- a/prometheus-operator/aggregate/base/kustomization.yaml
+++ b/prometheus-operator/aggregate/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-bases:
-  - ../../operator/overlays/beta
-  - ../../instance/overlays/example
+resources:
+- ../../operator/overlays/beta
+- ../../instance/overlays/example

--- a/prometheus-operator/aggregate/overlays/example/kustomization.yaml
+++ b/prometheus-operator/aggregate/overlays/example/kustomization.yaml
@@ -3,9 +3,8 @@ kind: Kustomization
 
 namespace: prom-test
 
-bases:
-  - ../../base
 
 resources:
-  - namespace.yaml
-  - operator-group.yaml
+- namespace.yaml
+- operator-group.yaml
+- ../../base

--- a/prometheus-operator/instance/overlays/example/kustomization.yaml
+++ b/prometheus-operator/instance/overlays/example/kustomization.yaml
@@ -1,13 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 resources:
-  - prometheus-sa.yaml
-  - prometheus-rbac.yaml
-  - prometheus-proxy-rbac.yaml
-  - prometheus.yaml
-  - prometheus-service.yaml
-  - prometheus-route.yaml
+- prometheus-sa.yaml
+- prometheus-rbac.yaml
+- prometheus-proxy-rbac.yaml
+- prometheus.yaml
+- prometheus-service.yaml
+- prometheus-route.yaml
+- ../../base

--- a/prometheus-operator/operator/base/kustomization.yaml
+++ b/prometheus-operator/operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - prometheus-subscription.yaml
+- prometheus-subscription.yaml

--- a/prometheus-operator/operator/overlays/beta/kustomization.yaml
+++ b/prometheus-operator/operator/overlays/beta/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    version: v1alpha1
+resources:
+- ../../base

--- a/quay-registry-operator/operator/base/kustomization.yaml
+++ b/quay-registry-operator/operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - quay-registry-operator-subscription.yaml
+- quay-registry-operator-subscription.yaml

--- a/quay-registry-operator/operator/overlays/stable-3.6/kustomization.yaml
+++ b/quay-registry-operator/operator/overlays/stable-3.6/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: quay-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: quay-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/quay-registry-operator/operator/overlays/stable-3.7/kustomization.yaml
+++ b/quay-registry-operator/operator/overlays/stable-3.7/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: quay-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: quay-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/quay-registry-operator/operator/overlays/stable-3.8/kustomization.yaml
+++ b/quay-registry-operator/operator/overlays/stable-3.8/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: quay-operator
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: quay-operator
+    namespace: openshift-operators
+    version: v1alpha1

--- a/rhoda-operator/operator/base/kustomization.yaml
+++ b/rhoda-operator/operator/base/kustomization.yaml
@@ -1,9 +1,8 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - catalogsource.yaml
-  - namespace.yaml
-  - operatorgroup.yaml
-  - subscription.yaml
+- catalogsource.yaml
+- namespace.yaml
+- operatorgroup.yaml
+- subscription.yaml

--- a/rhoda-operator/operator/overlays/release-0.1.5/kustomization.yaml
+++ b/rhoda-operator/operator/overlays/release-0.1.5/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: dbaas-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'alpha'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'alpha'
+  target:
+    kind: Subscription
+    name: dbaas-operator
+resources:
+- ../../base

--- a/rhods-operator/operator/base/kustomization.yaml
+++ b/rhods-operator/operator/base/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: redhat-ods-operator
 
 resources:
-  - redhat-ods-operator-namespace.yaml
-  - redhat-ods-operator-operatorgroup.yaml
-  - rhods-operator-subscription.yaml
+- redhat-ods-operator-namespace.yaml
+- redhat-ods-operator-operatorgroup.yaml
+- rhods-operator-subscription.yaml

--- a/rhods-operator/operator/overlays/stable/kustomization.yaml
+++ b/rhods-operator/operator/overlays/stable/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: rhods-operator
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: rhods-operator
+    version: v1alpha1
+resources:
+- ../../base

--- a/rhsso/instance/base/kustomization.yaml
+++ b/rhsso/instance/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - sso.yaml
+- sso.yaml

--- a/rhsso/instance/overlays/crc/kustomization.yaml
+++ b/rhsso/instance/overlays/crc/kustomization.yaml
@@ -1,28 +1,27 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 #  - ../../base/openshift-authentication
 
 resources:
-  - oauth-rhsso-openid.yaml
-  - openshift-user.yaml
-  - rhsso-default-cluster-admin-user.yaml
-  - client-secret.yaml
-  - openshift-realm.yaml
-  - openshift-client.yaml
+- oauth-rhsso-openid.yaml
+- openshift-user.yaml
+- rhsso-default-cluster-admin-user.yaml
+- client-secret.yaml
+- openshift-realm.yaml
+- openshift-client.yaml
+- ../../base
 
-patchesJson6902:
-  - target:
-      group: keycloak.org
-      version: v1alpha1
-      kind: KeycloakClient
-      name: openshift-client
-    path: patch-redirect-uri.yaml
-  - target:
-      group: config.openshift.io
-      version: v1
-      kind: OAuth
-      name: cluster
-    path: patch-issuer.yaml
+patches:
+- path: patch-redirect-uri.yaml
+  target:
+    group: keycloak.org
+    kind: KeycloakClient
+    name: openshift-client
+    version: v1alpha1
+- path: patch-issuer.yaml
+  target:
+    group: config.openshift.io
+    kind: OAuth
+    name: cluster
+    version: v1

--- a/rhsso/instance/overlays/default/kustomization.yaml
+++ b/rhsso/instance/overlays/default/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/rhsso/instance/overlays/rhpds/kustomization.yaml
+++ b/rhsso/instance/overlays/rhpds/kustomization.yaml
@@ -1,25 +1,24 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 resources:
-  - oauth-rhsso-openid.yaml
-  - client-secret.yaml
-  - openshift-realm.yaml
-  - openshift-client.yaml
+- oauth-rhsso-openid.yaml
+- client-secret.yaml
+- openshift-realm.yaml
+- openshift-client.yaml
+- ../../base
 
-patchesJson6902:
-  - target:
-      group: keycloak.org
-      version: v1alpha1
-      kind: KeycloakClient
-      name: openshift-client
-    path: patch-redirect-uri.yaml
-  - target:
-      group: config.openshift.io
-      version: v1
-      kind: OAuth
-      name: cluster
-    path: patch-issuer.yaml
+patches:
+- path: patch-redirect-uri.yaml
+  target:
+    group: keycloak.org
+    kind: KeycloakClient
+    name: openshift-client
+    version: v1alpha1
+- path: patch-issuer.yaml
+  target:
+    group: config.openshift.io
+    kind: OAuth
+    name: cluster
+    version: v1

--- a/rhsso/operator/base/kustomization.yaml
+++ b/rhsso/operator/base/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - rhsso-operatorgroup.yaml
-  - rhsso-subscription.yaml
-  - namespace.yaml
+- rhsso-operatorgroup.yaml
+- rhsso-subscription.yaml
+- namespace.yaml

--- a/rhsso/operator/overlays/alpha/kustomization.yaml
+++ b/rhsso/operator/overlays/alpha/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: sso
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: rhsso-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'alpha'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'alpha'
+  target:
+    kind: Subscription
+    name: rhsso-operator
+resources:
+- ../../base

--- a/rhsso/operator/overlays/stable/kustomization.yaml
+++ b/rhsso/operator/overlays/stable/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: sso
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-      name: rhsso-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable'
+  target:
+    kind: Subscription
+    name: rhsso-operator
+resources:
+- ../../base

--- a/rhsso/rhsso-standalone/base/kustomization.yaml
+++ b/rhsso/rhsso-standalone/base/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - sso-postgresql-pvc.yaml
-  - sso-credential-secret.yaml
-  - sso-db-secret.yaml
-  - sso-probes-cm.yaml
-  - sso-postgresql-deploy.yaml
-  - sso-postgresql-svc.yaml
-  - sso-ss.yaml
-  - sso-svc.yaml
-  - sso-discovery-svc.yaml
-  - sso-route.yaml
+- sso-postgresql-pvc.yaml
+- sso-credential-secret.yaml
+- sso-db-secret.yaml
+- sso-probes-cm.yaml
+- sso-postgresql-deploy.yaml
+- sso-postgresql-svc.yaml
+- sso-ss.yaml
+- sso-svc.yaml
+- sso-discovery-svc.yaml
+- sso-route.yaml

--- a/rhsso/rhsso-standalone/overlays/default/kustomization.yaml
+++ b/rhsso/rhsso-standalone/overlays/default/kustomization.yaml
@@ -3,8 +3,7 @@ kind: Kustomization
 
 namespace: sso
 
-bases:
-  - ../../base
 
 resources:
-  - namespace.yaml
+- namespace.yaml
+- ../../base

--- a/sealed-secrets-operator/base/kustomization.yaml
+++ b/sealed-secrets-operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.4/controller.yaml
+- https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.4/controller.yaml

--- a/sealed-secrets-operator/overlays/default/kustomization.yaml
+++ b/sealed-secrets-operator/overlays/default/kustomization.yaml
@@ -4,17 +4,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: sealed-secrets
 
 # Include the base Sealed Secrets manifests.
-bases:
-  - ../../base
 
 resources:
-  - sealed-secrets-namespace.yaml
+- sealed-secrets-namespace.yaml
+- ../../base
 
 # Remove the SCC requiring anyuid
 patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: sealed-secrets-controller
-    path: patch-sealed-secrets.yaml
+- path: patch-sealed-secrets.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: sealed-secrets-controller
+    version: v1

--- a/seldon-operator/operator/base/kustomization.yaml
+++ b/seldon-operator/operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - seldon-operator-subscription.yaml
+- seldon-operator-subscription.yaml

--- a/seldon-operator/operator/overlays/stable/kustomization.yaml
+++ b/seldon-operator/operator/overlays/stable/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: seldon-operator-certified
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: seldon-operator-certified
+    version: v1alpha1
+resources:
+- ../../base

--- a/selenium/base/kustomization.yaml
+++ b/selenium/base/kustomization.yaml
@@ -1,25 +1,25 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - centos7-is.yaml
-  - selenium-base-bc.yaml
-  - selenium-base-is.yaml
-  - selenium-hub-bc.yaml
-  - selenium-hub-dc.yaml
-  - selenium-hub-is.yaml
-  - selenium-hub-route.yaml
-  - selenium-hub-svc.yaml
-  - selenium-node-base-bc.yaml
-  - selenium-node-base-is.yaml
-  - selenium-node-chrome-bc.yaml
-  - selenium-node-chrome-dc.yaml
-  - selenium-node-chrome-debug-bc.yaml
-  - selenium-node-chrome-debug-dc.yaml
-  - selenium-node-chrome-debug-is.yaml
-  - selenium-node-chrome-is.yaml
-  - selenium-node-firefox-bc.yaml
-  - selenium-node-firefox-dc.yaml
-  - selenium-node-firefox-debug-bc.yaml
-  - selenium-node-firefox-debug-dc.yaml
-  - selenium-node-firefox-debug-is.yaml
-  - selenium-node-firefox-is.yaml
+- centos7-is.yaml
+- selenium-base-bc.yaml
+- selenium-base-is.yaml
+- selenium-hub-bc.yaml
+- selenium-hub-dc.yaml
+- selenium-hub-is.yaml
+- selenium-hub-route.yaml
+- selenium-hub-svc.yaml
+- selenium-node-base-bc.yaml
+- selenium-node-base-is.yaml
+- selenium-node-chrome-bc.yaml
+- selenium-node-chrome-dc.yaml
+- selenium-node-chrome-debug-bc.yaml
+- selenium-node-chrome-debug-dc.yaml
+- selenium-node-chrome-debug-is.yaml
+- selenium-node-chrome-is.yaml
+- selenium-node-firefox-bc.yaml
+- selenium-node-firefox-dc.yaml
+- selenium-node-firefox-debug-bc.yaml
+- selenium-node-firefox-debug-dc.yaml
+- selenium-node-firefox-debug-is.yaml
+- selenium-node-firefox-is.yaml

--- a/sonarqube8/base/kustomization.yaml
+++ b/sonarqube8/base/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - postgresql-data-pvc.yaml
-  - postgresql-dc.yaml
-  - postgresql-svc.yaml
-  - sonarqube-data-pvc.yaml
-  - sonarqube-deployment.yaml
-  - sonarqube-route.yaml
-  - sonarqube-svc.yaml
+- postgresql-data-pvc.yaml
+- postgresql-dc.yaml
+- postgresql-svc.yaml
+- sonarqube-data-pvc.yaml
+- sonarqube-deployment.yaml
+- sonarqube-route.yaml
+- sonarqube-svc.yaml

--- a/sonarqube8/overlays/default/kustomization.yaml
+++ b/sonarqube8/overlays/default/kustomization.yaml
@@ -2,5 +2,5 @@
 # Point to this directory in the "bases" field.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
+resources:
+- ../../base

--- a/sonarqube8/overlays/plugins/kustomization.yaml
+++ b/sonarqube8/overlays/plugins/kustomization.yaml
@@ -3,8 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 resources:
-  - configure-sonarqube-job.yaml
+- configure-sonarqube-job.yaml
+- ../../base

--- a/submariner-operator/base/kustomization.yaml
+++ b/submariner-operator/base/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - operatorgroup.yaml
-  - subscription.yaml
+- namespace.yaml
+- operatorgroup.yaml
+- subscription.yaml

--- a/submariner-operator/overlays/stable-0-12/kustomization.yaml
+++ b/submariner-operator/overlays/stable-0-12/kustomization.yaml
@@ -1,18 +1,17 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: submariner
-      namespace: submariner-operator
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: 'stable-0.12'
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: 'stable-0.12'
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: submariner
+    namespace: submariner-operator
+    version: v1alpha1
+resources:
+- ../../base

--- a/topology-aware-lifecycle-manager-operator/base/kustomization.yaml
+++ b/topology-aware-lifecycle-manager-operator/base/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - talm-subscription.yaml
+- talm-subscription.yaml

--- a/topology-aware-lifecycle-manager-operator/overlays/stable/kustomization.yaml
+++ b/topology-aware-lifecycle-manager-operator/overlays/stable/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: openshift-topology-aware-lifecycle-manager-subscription
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-topology-aware-lifecycle-manager-subscription
+    namespace: openshift-operators
+    version: v1alpha1

--- a/virtualization-operator/base/kustomization.yaml
+++ b/virtualization-operator/base/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - virtualization-operator-group.yaml
-  - virtualization-subscription.yaml
+- namespace.yaml
+- virtualization-operator-group.yaml
+- virtualization-subscription.yaml

--- a/virtualization-operator/overlays/emulation/kustomization.yaml
+++ b/virtualization-operator/overlays/emulation/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesStrategicMerge:
-  - patch-emulation.yaml
+resources:
+- ../../base
+patches:
+- path: patch-emulation.yaml

--- a/volsync/base/kustomization.yaml
+++ b/volsync/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - volsync-operator-subscription.yaml
+- volsync-operator-subscription.yaml

--- a/volsync/overlays/stable/kustomization.yaml
+++ b/volsync/overlays/stable/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../base
 
-patchesJson6902:
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: volsync-product
-      namespace: openshift-operators
-    path: patch-channel.yaml
+resources:
+- ../../base
+patches:
+- path: patch-channel.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: volsync-product
+    namespace: openshift-operators
+    version: v1alpha1

--- a/web-terminal-operator/operator/base/kustomization.yaml
+++ b/web-terminal-operator/operator/base/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: openshift-operators
 
 resources:
-  - web-terminal-subscription.yaml
+- web-terminal-subscription.yaml

--- a/web-terminal-operator/operator/overlays/fast/kustomization.yaml
+++ b/web-terminal-operator/operator/overlays/fast/kustomization.yaml
@@ -3,10 +3,10 @@ kind: Kustomization
 
 namespace: openshift-operators
 
-bases:
-  - ../../base
 
 patches:
-  - target:
-      kind: Subscription
-    path: patch-channel.yaml
+- path: patch-channel.yaml
+  target:
+    kind: Subscription
+resources:
+- ../../base


### PR DESCRIPTION
Kustomize has deprecated a number of elements (such as bases), in version 5.x and higher there are lots of deprecation warning messages. However they have provided a mechanism to upgrade these kustomization.yaml files using: `kustomize edit fix --vars`

In this PR the following steps were performed:
1. Run the upgrade: 

`find . -type f -name kustomization.yaml -exec bash -c 'FN="{}"; cd "${FN%kustomization.yaml}"; kustomize edit fix --vars; cd -' \;`

2. Fix the yaml linting (tabs and spaces):