### PR TITLE
Add stable-1.3 channel for the openshift-sandboxed-containers

### DIFF
--- a/openshift-sandboxed-containers/README.md
+++ b/openshift-sandboxed-containers/README.md
@@ -6,6 +6,14 @@ OpenShift sandboxed containers requires OpenShift Container Platform >= 4.10.
 
 Note that the operator will install a MachineConfig resource to enable the sandboxed containers extension on the cluster node. This will cause the cluster nodes to restart.
 
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+The current *overlays* available are for the following channels:
+
+* [preview-1.1](operator/overlays/preview-1.1)
+* [stable-1.2](operator/overlays/stable-1.2)
+* [stable-1.3](operator/overlays/stable-1.3)
+
 ## Usage
 
 Install the OpenShift sandboxed containers operator:

--- a/openshift-sandboxed-containers/operator/overlays/stable-1.3/kustomization.yaml
+++ b/openshift-sandboxed-containers/operator/overlays/stable-1.3/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-sandboxed-containers-operator
+
+bases:
+  - ../../base
+
+patchesStrategicMerge:
+  - openshift-sandboxed-containers-operator-sub.yaml

--- a/openshift-sandboxed-containers/operator/overlays/stable-1.3/openshift-sandboxed-containers-operator-sub.yaml
+++ b/openshift-sandboxed-containers/operator/overlays/stable-1.3/openshift-sandboxed-containers-operator-sub.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sandboxed-containers-operator
+spec:
+  channel: stable-1.3


### PR DESCRIPTION
Add stable-1.3 channel for the openshift-sandboxed-containers

Reference:
[OpenShift 4.12 documentation](https://docs.openshift.com/container-platform/4.12/sandboxed_containers/deploying-sandboxed-container-workloads.html#deploying-sandboxed-containers-workloads-web-console)