### PR TITLE
switch serverless apis to beta

### DIFF
--- a/serverless-operator/instance/knative-eventing/base/knative-eventing-instance.yaml
+++ b/serverless-operator/instance/knative-eventing/base/knative-eventing-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
   name: knative-eventing

--- a/serverless-operator/instance/knative-serving/base/knative-serving-instance.yaml
+++ b/serverless-operator/instance/knative-serving/base/knative-serving-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving


### PR DESCRIPTION
The serving and eventing v1alpha1 APIs were depreciated in 1.27:

https://docs.openshift.com/container-platform/4.12/serverless/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes

KnativeKafka is still utilizing v1alpha1 API