### PR TITLE
updated to v0.10, stable-v1

### DIFF
--- a/cert-manager-operator/README.md
+++ b/cert-manager-operator/README.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-This deploys the cert-manager operator which is currently Tech Preview in 4.10. If you are not familiar with cert-manager, it provisions and manages TLS certificates for you automatically using one or more configured Issuers. It's great for providing a self-service capability around TLS certificates out of the OpenShift platform.
+This deploys the cert-manager operator. If you are not familiar with cert-manager, it provisions and manages TLS certificates for you automatically using one or more configured Issuers. It's great for providing a self-service capability around TLS certificates out of the OpenShift platform.
 
 Documentation on OpenShift cert-manager is available [here](https://docs.openshift.com/container-platform/4.10/security/cert_manager_operator/index.html).
 

--- a/cert-manager-operator/operator/base/namespace.yaml
+++ b/cert-manager-operator/operator/base/namespace.yaml
@@ -4,5 +4,5 @@ metadata:
   annotations:
     openshift.io/display-name: Red Hat Certificate Manager Operator
   labels:
-    openshift.io/cluster-monitoring: 'true'
-  name: openshift-cert-manager-operator
+    openshift.io/cluster-monitoring: "true"
+  name: cert-manager-operator

--- a/cert-manager-operator/operator/base/operator-group.yaml
+++ b/cert-manager-operator/operator/base/operator-group.yaml
@@ -1,5 +1,9 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-cert-manager-operator
-spec: {}
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+    - cert-manager-operator
+  upgradeStrategy: Default

--- a/cert-manager-operator/operator/base/subscription.yaml
+++ b/cert-manager-operator/operator/base/subscription.yaml
@@ -1,11 +1,14 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
+  labels:
+    operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator: ""
   name: openshift-cert-manager-operator
-  namespace: openshift-cert-manager-operator
+  namespace: cert-manager-operator
 spec:
-  channel: tech-preview
+  channel: stable-v1
   installPlanApproval: Automatic
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  startingCSV: cert-manager-operator.v1.10.2


### PR DESCRIPTION
* updated to use stable-v1 channel
* change manifests so that they are closer to what is deployed when doing a manual web ui based installation of the operator

https://docs.openshift.com/container-platform/4.12/security/cert_manager_operator/cert-manager-operator-install.html describes the process

Signed-off-by: Christoph Görn <goern@redhat.com>
