### PR TITLE
Remove namespace from Group Sync Operator

### DIFF
--- a/group-sync-operator/overlays/alpha/kustomization.yaml
+++ b/group-sync-operator/overlays/alpha/kustomization.yaml
@@ -2,8 +2,6 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
-namespace: openshift-operators
-
 resources:
   - ../../base
 


### PR DESCRIPTION
Remove namespace from the `kustomization.yaml` in the from Group Sync Operator alpha overlay