### PR TITLE
remove cluster registry dependency from ODF console plugin enabler job

### DIFF
--- a/openshift-data-foundation-operator/operator/base/enable-console-plugin-job.yaml
+++ b/openshift-data-foundation-operator/operator/base/enable-console-plugin-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: labeler
-          image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+          image: registry.redhat.io/openshift4/ose-cli
           env:
             - name: PLUGIN_NAME
               value: 'odf-console'


### PR DESCRIPTION
Use the OpenShift client image from Red Hat registry rather than assuming the local cluster registry has already been deployed with an alternative storage back end.

fixes #171 