### PR TITLE
Changed ACS secured cluster collection type to EBPF

### DIFF
--- a/advanced-cluster-security-operator/instance/base/secured-cluster.yaml
+++ b/advanced-cluster-security-operator/instance/base/secured-cluster.yaml
@@ -12,6 +12,6 @@ spec:
     listenOnUpdates: false
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints


### PR DESCRIPTION
Changed the mode of `SecuredCluster` collection to `EBPF` as `KernelModule` was deprecated