### PR TITLE
added nvidia operator

### DIFF
--- a/nfd/instance/README.md
+++ b/nfd/instance/README.md
@@ -22,13 +22,13 @@ The options for this operator are the following *overlays*:
 If you have cloned the `gitops-catalog` repository, you can install the Storage System by running from the root `gitops-catalog` directory
 
 ```
-oc apply -k openshift-nfd-operator/instance/overlays/default
+oc apply -k nfd/instance/overlays/default
 ```
 
 Or, without cloning:
 
 ```
-oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-nfd-operator/instance/overlays/default
+oc apply -k https://github.com/redhat-cop/gitops-catalog/nfd/instance/overlays/default
 ```
 
 As part of a different overlay in your own GitOps repo:
@@ -38,5 +38,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/redhat-cop/gitops-catalog/openshift-nfd-operator/instance/overlays/default?ref=main
+  - github.com/redhat-cop/gitops-catalog/nfd/instance/overlays/default?ref=main
 ```

--- a/nvidia-gpu-operator/README.md
+++ b/nvidia-gpu-operator/README.md
@@ -1,0 +1,42 @@
+# NVIDIA GPU Operator
+
+Installs the NVIDIA GPU Operator.
+
+## Prerequisites
+
+First, install the [NVIDIA GPU Operator](../operator) in your cluster.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+## Overlays
+
+The options for this operator are the following *overlays*:
+* [default](overlays/default)
+
+### Default
+
+[default](overlays/default) configures the NVIDIA GPU Operator.
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install the Storage System by running from the root `gitops-catalog` directory
+
+```
+oc apply -k nvidia-gpu-operator/operator/overlays/default
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/nvidia-gpu-operator/instance/overlays/default
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/redhat-cop/gitops-catalog/nvidia-gpu-operator/instance/overlays/default?ref=main
+```

--- a/nvidia-gpu-operator/operator/base/kustomization.yaml
+++ b/nvidia-gpu-operator/operator/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operator-group.yaml
+  - subscription.yaml

--- a/nvidia-gpu-operator/operator/base/namespace.yaml
+++ b/nvidia-gpu-operator/operator/base/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "NVIDIA GPU Operator"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: nvidia-gpu-operator

--- a/nvidia-gpu-operator/operator/base/operator-group.yaml
+++ b/nvidia-gpu-operator/operator/base/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nvidia-gpu-operator-group
+  namespace: nvidia-gpu-operator
+spec:
+  targetNamespaces:
+    - nvidia-gpu-operator

--- a/nvidia-gpu-operator/operator/base/subscription.yaml
+++ b/nvidia-gpu-operator/operator/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  namespace: nvidia-gpu-operator
+spec:
+  channel: patch-me-see-overlays-dir
+  installPlanApproval: Automatic
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/nvidia-gpu-operator/operator/overlays/default/kustomization.yaml
+++ b/nvidia-gpu-operator/operator/overlays/default/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Subscription
+      name: gpu-operator-certified
+    path: patch-channel.yaml

--- a/nvidia-gpu-operator/operator/overlays/default/patch-channel.yaml
+++ b/nvidia-gpu-operator/operator/overlays/default/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable


### PR DESCRIPTION
Tested in OCP4.13 BM and in ROSA 4.13

```md
oc get subs -A | grep nvidia
nvidia-gpu-operator                        gpu-operator-certified                gpu-operator-certified            certified-operators                        stable
```

```md
oc get csv -A | grep "NVIDIA GPU Operator"
nvidia-gpu-operator                                gpu-operator-certified.v23.6.1                     NVIDIA GPU Operator                23.6.1                gpu-operator-certified.v23.6.0                     Succeeded
```

Adjusted nfd to the new name