### PR TITLE
use openshift client image from redhat registry for node-labeler job

### DIFF
--- a/openshift-data-foundation-operator/config-helpers/node-labeler/base/node-label-job.yaml
+++ b/openshift-data-foundation-operator/config-helpers/node-labeler/base/node-label-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: labeler
-          image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+          image: registry.redhat.io/openshift4/ose-cli
           env:
             - name: selector
               value: 'node-role.kubernetes.io/worker'


### PR DESCRIPTION
Use the OpenShift client image from Red Hat registry rather than assuming the local cluster registry has already been deployed with an alternative storage back end.