### PR TITLE
Sort wordlist script

### DIFF
--- a/.wordlist-md
+++ b/.wordlist-md
@@ -41,8 +41,8 @@ KokuMetricsConfig
 Kubernetes
 Kyverno
 LDAP
-Lifecycle
 LVM
+Lifecycle
 MTA
 MachineConfig
 MultiClusterHub

--- a/.wordlist-md
+++ b/.wordlist-md
@@ -197,5 +197,6 @@ thanos
 truly
 vSphere
 vsphere
+wordlist
 workspaces
 yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ This repo is configured to run a Spell Check on the repo as part of a Pull Reque
 
 Unfortunately there are many technical words that often get flagged by the spell checker that are acceptable.  When submitting a PR if there are words that the spell checker flags that should be allowed, those words can be added to the [.wordlist](.wordlist) file.
 
-Simply add any missing words to the file and run the following to sort the file before commiting:
+Simply add any missing words to the file and run the following to sort the file before committing:
 
 ```sh
 ./scripts/sort-wordlist.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,15 @@ metadata:
 ```
 
 The `olm.providedAPIs` annotation is automatically added by OLM once a subscription has been installed.  Including this annotation may cause reconciliation loops when utilizing these examples with GitOps tools such as ArgoCD.
+
+## Spell Checking
+
+This repo is configured to run a Spell Check on the repo as part of a Pull Request to help keep documentation correct.
+
+Unfortunately there are many technical words that often get flagged by the spell checker that are acceptable.  When submitting a PR if there are words that the spell checker flags that should be allowed, those words can be added to the [.wordlist](.wordlist) file.
+
+Simply add any missing words to the file and run the following to sort the file before commiting:
+
+```sh
+./scripts/sort-wordlist.sh
+```

--- a/scripts/sort-wordlist.sh
+++ b/scripts/sort-wordlist.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+TEMP_WORDLIST=.temp-wordlist-md
+WORDLIST=.wordlist-md
+
+if [ -e ${TEMP_WORDLIST} ] ; then
+    rm ${TEMP_WORDLIST}
+fi
+cat .wordlist-md | LC_COLLATE=C sort -u > ${TEMP_WORDLIST}
+
+if [ -e ${WORDLIST} ] ; then
+    rm ${WORDLIST}
+fi
+
+mv ${TEMP_WORDLIST} ${WORDLIST}


### PR DESCRIPTION
Adding a script to help sort the words consistently across MacOS and RHEL.

It appears that MacOS and RHEL have a slightly different default configuration for how to handle the sort with Capitol letters so the script will work the same for both environments.

I also added a few quick notes on the contributing guide for the spell checker.