### PR TITLE
add policy-generator component

### DIFF
--- a/openshift-gitops-operator/instance/components/kustomize-build-policy-generator/README.md
+++ b/openshift-gitops-operator/instance/components/kustomize-build-policy-generator/README.md
@@ -1,4 +1,4 @@
-# kustomize-build-enable-helm
+# kustomize-build-policy-generator
 
 ## Purpose
 This component is designed to turn on the `--enable-helm` feature of `kustomize build` in ArgoCD to support helm charts inside of a kustomization.yaml file.
@@ -17,13 +17,13 @@ resources:
   - ../../base
 
 components:
-  - ../../components/kustomize-build-enable-helm
+  - ../../components/kustomize-build-policy-generator
 ```
 
 ## Known Incompatibilities
 
-### kustomize-build-policy-generator
+### kustomize-build-enable-helm
 
-This component is not compatible with the [kustomize-build-policy-generator](openshift-gitops-operator/instance/components/kustomize-build-policy-generator) component.
+This component is not compatible with the [kustomize-build-enable-helm](openshift-gitops-operator/instance/components/kustomize-build-enable-helm) component.
 
 Both components are attempting to patch the `spec.kustomizeBuildOptions` field.

--- a/openshift-gitops-operator/instance/components/kustomize-build-policy-generator/kustomization.yaml
+++ b/openshift-gitops-operator/instance/components/kustomize-build-policy-generator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch-enable-policy-generator.yaml
+    target:
+      kind: ArgoCD

--- a/openshift-gitops-operator/instance/components/kustomize-build-policy-generator/patch-enable-policy-generator.yaml
+++ b/openshift-gitops-operator/instance/components/kustomize-build-policy-generator/patch-enable-policy-generator.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  repo:
+    env:
+    - name: KUSTOMIZE_PLUGIN_HOME
+      value: /etc/kustomize/plugin
+    initContainers:
+    - args:
+      - -c
+      - cp /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
+        /policy-generator/PolicyGenerator
+      command:
+      - /bin/bash
+      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.8
+      name: policy-generator-install
+      volumeMounts:
+      - mountPath: /policy-generator
+        name: policy-generator
+    volumeMounts:
+    - mountPath: /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator
+      name: policy-generator
+    volumes:
+    - emptyDir: {}
+      name: policy-generator
+  kustomizeBuildOptions: --enable-alpha-plugins


### PR DESCRIPTION
This adds a new component for patching the argocd instance to enable the ACM policy generator plugin.

Since this component has a conflict with the kustomize-build-enable-helm component I have added some notes on both to indicate that they are not compatible with each other.