### PR TITLE
enable argo sync concurrent to CRD creation

### DIFF
--- a/nmstate/instance/nmstate-nmstate.yaml
+++ b/nmstate/instance/nmstate-nmstate.yaml
@@ -2,6 +2,8 @@ apiVersion: nmstate.io/v1beta1
 kind: NMState
 metadata:
   name: nmstate
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   nodeSelector:
     beta.kubernetes.io/arch: amd64


### PR DESCRIPTION
Skip dry run validation on creation of nmstate resource.
This enables simultaneous sync of nmstate/operator and nmstate/instance kustomizations in a single Argo CD sync.