### PR TITLE
disable comment indentation check

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -9,3 +9,4 @@ rules:
   line-length: disable
   truthy:
     ignore: .github/workflows/
+  comments-indentation: disable


### PR DESCRIPTION
Disable the yamllint config that checks for comment indentation to resolve warning that has been popping up on all PRs.