### PR TITLE
Updating the file integrity operator

### DIFF
--- a/file-integrity-operator/README.md
+++ b/file-integrity-operator/README.md
@@ -6,10 +6,10 @@ This is to deploy the [File Integrity Operator](https://docs.openshift.com/conta
 
 ## Install Operator Only
 
-Reference on of the `operator/overlay` directories.  For example:
+Reference on of the `operator/overlays` directories.  For example:
 
 ```
-oc apply -k file-integrity-operator/operator/overlays/release-0.1
+oc apply -k file-integrity-operator/operator/overlays/stable
 ```
 
 Or as part of your own `kustomization.yaml` file:
@@ -19,7 +19,7 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 resources:
-- github.com/redhat-cop/gitops-catalog/file-integrity-operator/operator/overlays/release-0.1?ref=main
+- github.com/redhat-cop/gitops-catalog/file-integrity-operator/operator/overlays/stable?ref=main
 ```
 
 ## Configure File Integrity Scans

--- a/file-integrity-operator/operator/overlays/README.md
+++ b/file-integrity-operator/operator/overlays/README.md
@@ -2,10 +2,14 @@
 
 ## Which Channel to Use?
 
-The channel naming is particularly confusing for this operator.  To determine which version to use, please check the docs for the OpenShift release you are using (make sure you change the version in the drop down):
+To determine which version to use, please check the docs for the OpenShift release you are using (make sure you change the version in the drop down):
 * [OpenShift File Integrity Operator Docs](https://docs.openshift.com/container-platform/latest/security/file_integrity_operator/file-integrity-operator-installation.html)
 
-Currently, the supported channel for OCP 4.6, 4.7 and 4.8 is `release-0.1`.   The `4.7` channel is not included, as it is legacy.  More channels will be added as they become available.
+Formerly, the supported channel for OCP 4.6, 4.7 and 4.8 were `release-0.1`.   The `4.7` channel is not included, as it is legacy.
+
+Currently, the supported channel for OCP 4 are `stable` and `v1`.
 
 Channels:
 * [release-0.1](release-0.1)
+* [stable](stable)
+* [v1](v1)

--- a/file-integrity-operator/operator/overlays/stable/kustomization.yaml
+++ b/file-integrity-operator/operator/overlays/stable/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: openshift-file-integrity
+
+resources:
+  - ../../base
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/channel
+        value: 'stable'
+    target:
+      kind: Subscription
+      name: file-integrity-operator

--- a/file-integrity-operator/operator/overlays/v1/kustomization.yaml
+++ b/file-integrity-operator/operator/overlays/v1/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: openshift-file-integrity
+
+resources:
+  - ../../base
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/channel
+        value: 'v1'
+    target:
+      kind: Subscription
+      name: file-integrity-operator


### PR DESCRIPTION
Added two new channels (`stable `and `v1`) for the `file integrity operator`.
Replaced the old `release-0.1` channel in the operator readme by the `stable` one.

> The File Integrity Operator is now stable and the release channel is upgraded to stable. Future releases will follow [Semantic Versioning](https://semver.org/). To access the latest release, see [Updating the File Integrity Operator](https://docs.openshift.com/container-platform/4.14/security/file_integrity_operator/file-integrity-operator-updating.html#olm-preparing-upgrade_file-integrity-operator-updating).


Reference:
[Release notes](https://docs.openshift.com/container-platform/4.14/security/file_integrity_operator/file-integrity-operator-release-notes.html)