### PR TITLE
Adding Red Hat Developer Hub Operator

### DIFF
--- a/rhdh-operator/README.md
+++ b/rhdh-operator/README.md
@@ -10,9 +10,7 @@ Do not use the `base` directory directly, as you will need to patch the `channel
 
 The current *overlays* available are for the following channels:
 
-* [stable](operator/overlays/stable)
-* [stable-1.29](operator/overlays/stable-1.29)
-* [stable-1.30](operator/overlays/stable-1.30)
+* [fast](operator/overlays/fast)
 
 ## Usage
 

--- a/rhdh-operator/README.md
+++ b/rhdh-operator/README.md
@@ -1,0 +1,38 @@
+# Red Hat Developer Hub Operator
+
+Red Hat Developer Hub is a Red Hat supported version of Backstage. It comes with pre-built plug-ins, configuration settings, and deployment mechanisms, which can help streamline the process of setting up a self-managed internal developer portal for adopters who are just starting out.
+
+# Red Hat Developer Hub Operator
+
+Install Red Hat Developer Hub Operator.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+The current *overlays* available are for the following channels:
+
+* [stable](operator/overlays/stable)
+* [stable-1.29](operator/overlays/stable-1.29)
+* [stable-1.30](operator/overlays/stable-1.30)
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install Red Hat Developer Hub Operator based on the overlay of your choice by running from the root (`gitops-catalog`) directory.
+
+```
+oc apply -k rhdh-operator/operator/overlays/<channel>
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/rhdh-operator/operator/overlays/<channel>
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/redhat-cop/gitops-catalog/rhdh-operator/operator/overlays/<channel>?ref=main
+```

--- a/rhdh-operator/instance/base/backstage.yaml
+++ b/rhdh-operator/instance/base/backstage.yaml
@@ -1,0 +1,16 @@
+apiVersion: rhdh.redhat.com/v1alpha1
+kind: Backstage
+metadata:
+  name: developer-hub
+  namespace: rhdh-operator
+spec:
+  application:
+    appConfig:
+      mountPath: /opt/app-root/src
+    extraFiles:
+      mountPath: /opt/app-root/src
+    replicas: 1
+    route:
+      enabled: true
+  database:
+    enableLocalDb: true

--- a/rhdh-operator/instance/base/kustomization.yaml
+++ b/rhdh-operator/instance/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - backstage.yaml

--- a/rhdh-operator/instance/overlays/default/kustomization.yaml
+++ b/rhdh-operator/instance/overlays/default/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/rhdh-operator/operator/base/kustomization.yaml
+++ b/rhdh-operator/operator/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operator-group.yaml
+  - subscription.yaml

--- a/rhdh-operator/operator/base/namespace.yaml
+++ b/rhdh-operator/operator/base/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat Developer Hub Operator"
+  labels:
+    openshift.io/cluster-monitoring: 'true'
+  name: rhdh-operator

--- a/rhdh-operator/operator/base/operator-group.yaml
+++ b/rhdh-operator/operator/base/operator-group.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhdh-operator
+  namespace: rhdh-operator

--- a/rhdh-operator/operator/base/subscription.yaml
+++ b/rhdh-operator/operator/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhdh
+  namespace: rhdh-operator
+spec:
+  channel: patch-me-see-overlays-dir
+  installPlanApproval: Automatic
+  name: rhdh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/rhdh-operator/operator/overlays/fast/README.md
+++ b/rhdh-operator/operator/overlays/fast/README.md
@@ -1,0 +1,3 @@
+Installs the *OpenShift 4.7* channel version of the OpenShift Serverless Operator
+
+**Version: 1.1.0**

--- a/rhdh-operator/operator/overlays/fast/README.md
+++ b/rhdh-operator/operator/overlays/fast/README.md
@@ -1,3 +1,3 @@
-Installs the *OpenShift 4.7* channel version of the OpenShift Serverless Operator
+Installs the *OpenShift 4.15* channel version of the Red Hat Developer Hub Operator
 
 **Version: 1.1.0**

--- a/rhdh-operator/operator/overlays/fast/kustomization.yaml
+++ b/rhdh-operator/operator/overlays/fast/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Subscription
+      name: rhdh
+    path: patch-channel.yaml

--- a/rhdh-operator/operator/overlays/fast/patch-channel.yaml
+++ b/rhdh-operator/operator/overlays/fast/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: fast


### PR DESCRIPTION
'Red Hat Developer Hub Operator' is now generally available (GA).
Adding its:
1. operator
2. backstage instance.

Follows the same conventions as other operators with Readme.