### PR TITLE
Add OpenShift GitOps 1.12 channel

### DIFF
--- a/openshift-gitops-operator/README.md
+++ b/openshift-gitops-operator/README.md
@@ -15,6 +15,7 @@ The current *overlays* available are for the following channels:
 * [gitops-1.9](operator/overlays/gitops-1.9)
 * [gitops-1.10](operator/overlays/gitops-1.10)
 * [gitops-1.11](operator/overlays/gitops-1.11)
+* [gitops-1.12](operator/overlays/gitops-1.12)
 * [latest](operator/overlays/latest)
 * [preview](operator/overlays/preview)
 

--- a/openshift-gitops-operator/operator/overlays/gitops-1.12/kustomization.yaml
+++ b/openshift-gitops-operator/operator/overlays/gitops-1.12/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/openshift-gitops-operator
+
+patches:
+  - target:
+      kind: Subscription
+      name: openshift-gitops-operator
+    path: patch-subscription.yaml

--- a/openshift-gitops-operator/operator/overlays/gitops-1.12/patch-subscription.yaml
+++ b/openshift-gitops-operator/operator/overlays/gitops-1.12/patch-subscription.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: gitops-1.12
+- op: replace
+  path: /metadata/namespace
+  value: openshift-gitops-operator


### PR DESCRIPTION
Adds an overlay for the OpenShift GitOps operator 1.12 channel, following the updated naming convention from 1.11.