### PR TITLE
Update Grafana for V5

### DIFF
--- a/grafana-operator/base/instance/grafana-proxy-rbac.yaml
+++ b/grafana-operator/base/instance/grafana-proxy-rbac.yaml
@@ -27,4 +27,4 @@ roleRef:
   name: grafana-proxy
 subjects:
   - kind: ServiceAccount
-    name: grafana-instance-sa
+    name: grafana-sa

--- a/grafana-operator/base/instance/grafana-proxy-rbac.yaml
+++ b/grafana-operator/base/instance/grafana-proxy-rbac.yaml
@@ -18,7 +18,7 @@ rules:
       - subjectaccessreviews
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: grafana-proxy
 roleRef:

--- a/grafana-operator/base/instance/grafana-proxy-rbac.yaml
+++ b/grafana-operator/base/instance/grafana-proxy-rbac.yaml
@@ -4,18 +4,18 @@ kind: ClusterRole
 metadata:
   name: grafana-proxy
 rules:
-  - apiGroups:
+  - verbs:
+      - create
+    apiGroups:
       - authentication.k8s.io
     resources:
       - tokenreviews
-    verbs:
+  - verbs:
       - create
-  - apiGroups:
+    apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
-    verbs:
-      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -27,4 +27,4 @@ roleRef:
   name: grafana-proxy
 subjects:
   - kind: ServiceAccount
-    name: grafana-serviceaccount
+    name: grafana-instance-sa

--- a/grafana-operator/base/instance/grafana-proxy-rbac.yaml
+++ b/grafana-operator/base/instance/grafana-proxy-rbac.yaml
@@ -18,7 +18,7 @@ rules:
       - subjectaccessreviews
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: grafana-proxy
 roleRef:

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1beta1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   name: grafana

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: integreatly.org/v1beta1
 kind: Grafana
 metadata:
   name: grafana
@@ -8,8 +8,8 @@ spec:
       mode: "console"
       level: "warn"
     auth:
-      disable_login_form: false
-      disable_signout_menu: true
+      disable_login_form: "false"
+      disable_signout_menu: "true"
     auth.basic:
       enabled: true
     auth.anonymous:

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -51,7 +51,7 @@ spec:
                 - '-tls-key=/etc/tls/private/tls.key'
                 - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
                 - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
-                - '-openshift-service-account=grafana-instance-sa'
+                - '-openshift-service-account=grafana-sa'
                 - '-openshift-ca=/etc/pki/tls/cert.pem'
                 - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
                 - '-openshift-ca=/etc/proxy/certs/ca-bundle.crt'

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -12,17 +12,17 @@ spec:
     metadata:
       annotations:
         serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-instance-route"}}'
-  route:
-    spec:
-      port:
-        targetPort: https
-      tls:
-        termination: reencrypt
-      to:
-        kind: Service
-        name: grafana-service
-        weight: 100
-      wildcardPolicy: None
+  route: {}
+    # spec:
+    #   port:
+    #     targetPort: https
+    #   tls:
+    #     termination: reencrypt
+    #   to:
+    #     kind: Service
+    #     name: grafana-service
+    #     weight: 100
+    #   wildcardPolicy: None
   deployment:
     spec:
       template:
@@ -82,8 +82,8 @@ spec:
           port: 9091
           protocol: TCP
           targetPort: https
-  client:
-    preferIngress: false
+  # client:
+  #   preferIngress: false
   config:
     log:
       mode: "console"

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -11,9 +11,9 @@ spec:
       disable_login_form: "false"
       disable_signout_menu: "true"
     auth.basic:
-      enabled: true
+      enabled: "true"
     auth.anonymous:
-      enabled: true
+      enabled: "true"
   containers:
     - env:
         - name: SAR

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -3,71 +3,96 @@ kind: Grafana
 metadata:
   name: grafana
   labels:
-    instance: grafana
+    instance: "grafana"
 spec:
+  serviceAccount:
+    metadata:
+      annotations:
+        serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-instance-route"}}'
+  route:
+    spec:
+      port:
+        targetPort: https
+      tls:
+        termination: reencrypt
+      to:
+        kind: Service
+        name: grafana-instance-service
+        weight: 100
+      wildcardPolicy: None
+  deployment:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: grafana-tls
+            secret:
+              secretName: grafana-tls
+          - name: grafana-proxy
+            secret:
+              secretName: grafana-proxy
+          - name: ocp-injected-certs
+            configMap:
+              name: ocp-injected-certs
+          containers:
+            - args:
+                - '-provider=openshift'
+                - '-pass-basic-auth=false'
+                - '-https-address=:9091'
+                - '-http-address='
+                - '-email-domain=*'
+                - '-upstream=http://localhost:3000'
+                - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+                - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+                - '-tls-cert=/etc/tls/private/tls.crt'
+                - '-tls-key=/etc/tls/private/tls.key'
+                - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
+                - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
+                - '-openshift-service-account=grafana-instance-sa'
+                - '-openshift-ca=/etc/pki/tls/cert.pem'
+                - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+                - '-openshift-ca=/etc/proxy/certs/ca-bundle.crt'
+                - '-skip-auth-regex=^/metrics'
+              image: 'quay.io/openshift/origin-oauth-proxy'
+              name: grafana-proxy
+              ports:
+                - containerPort: 9091
+                  name: https
+              resources: { }
+              volumeMounts:
+                - mountPath: /etc/tls/private
+                  name: grafana-tls
+                  readOnly: false
+                - mountPath: /etc/proxy/secrets
+                  name: grafana-proxy
+                  readOnly: false
+                - mountPath: /etc/proxy/certs
+                  name: ocp-injected-certs
+                  readOnly: false
+  service:
+    metadata:
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: grafana-tls
+    spec:
+      ports:
+        - name: https
+          port: 9091
+          protocol: TCP
+          targetPort: https
+  client:
+    preferIngress: false
   config:
     log:
       mode: "console"
-      level: "warn"
-    auth:
-      disable_login_form: "false"
-      disable_signout_menu: "true"
-    auth.basic:
-      enabled: "true"
     auth.anonymous:
-      enabled: "true"
-  containers:
-    - env:
-        - name: SAR
-          value: '-openshift-sar={"resource": "namespaces", "verb": "get"}'
-      args:
-        - '-provider=openshift'
-        - '-pass-basic-auth=false'
-        - '-https-address=:9091'
-        - '-http-address='
-        - '-email-domain=*'
-        - '-upstream=http://localhost:3000'
-        - "$(SAR)"
-        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
-        - '-tls-cert=/etc/tls/private/tls.crt'
-        - '-tls-key=/etc/tls/private/tls.key'
-        - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
-        - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
-        - '-openshift-service-account=grafana-serviceaccount'
-        - '-openshift-ca=/etc/pki/tls/cert.pem'
-        - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
-        - '-skip-auth-regex=^/metrics'
-      image: 'registry.redhat.io/openshift4/ose-oauth-proxy:v4.6'
-      imagePullPolicy: Always
-      name: grafana-proxy
-      ports:
-        - containerPort: 9091
-          name: grafana-proxy
-      resources: {}
-      volumeMounts:
-        - mountPath: /etc/tls/private
-          name: secret-grafana-k8s-tls
-          readOnly: false
-        - mountPath: /etc/proxy/secrets
-          name: secret-grafana-k8s-proxy
-          readOnly: false
-  secrets:
-    - grafana-k8s-tls
-    - grafana-k8s-proxy
-  service:
-    ports:
-      - name: grafana-proxy
-        port: 9091
-        protocol: TCP
-        targetPort: grafana-proxy
-    annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: grafana-k8s-tls
-  ingress:
-    enabled: true
-    targetPort: grafana-proxy
-    termination: reencrypt
-  client:
-    preferService: true
-  serviceAccount:
-    annotations:
-      serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-route"}}'
+      enabled: "True"
+    auth:
+      disable_login_form: "False"
+      disable_signout_menu: "True"
+    auth.basic:
+      enabled: "True"
+    auth.proxy:
+      enabled: "True"
+      enable_login_token: "True"
+      header_property: "username"
+      header_name: "X-Forwarded-User"

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -2,6 +2,8 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   name: grafana
+  labels:
+    instance: grafana
 spec:
   config:
     log:
@@ -69,6 +71,3 @@ spec:
   serviceAccount:
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-route"}}'
-  dashboardLabelSelector:
-    - matchExpressions:
-        - { key: "app", operator: In, values: ['grafana'] }

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccount:
     metadata:
       annotations:
-        serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-instance-route"}}'
+        serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-route"}}'
   route:
     spec:
       port:

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -1,6 +1,9 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
   name: grafana
   labels:
     instance: "grafana"

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -20,7 +20,7 @@ spec:
         termination: reencrypt
       to:
         kind: Service
-        name: grafana-instance-service
+        name: grafana-service
         weight: 100
       wildcardPolicy: None
   deployment:

--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -12,17 +12,17 @@ spec:
     metadata:
       annotations:
         serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-instance-route"}}'
-  route: {}
-    # spec:
-    #   port:
-    #     targetPort: https
-    #   tls:
-    #     termination: reencrypt
-    #   to:
-    #     kind: Service
-    #     name: grafana-service
-    #     weight: 100
-    #   wildcardPolicy: None
+  route:
+    spec:
+      port:
+        targetPort: https
+      tls:
+        termination: reencrypt
+      to:
+        kind: Service
+        name: grafana-service
+        weight: 100
+      wildcardPolicy: None
   deployment:
     spec:
       template:
@@ -82,8 +82,8 @@ spec:
           port: 9091
           protocol: TCP
           targetPort: https
-  # client:
-  #   preferIngress: false
+  client:
+    preferIngress: false
   config:
     log:
       mode: "console"

--- a/grafana-operator/base/instance/injected-certs-cm.yaml
+++ b/grafana-operator/base/instance/injected-certs-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: ocp-injected-certs

--- a/grafana-operator/base/instance/kustomization.yaml
+++ b/grafana-operator/base/instance/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 
 resources:
   - session-secret.yaml
+  - injected-certs-cm.yaml
   - grafana-proxy-rbac.yaml
   - grafana.yaml

--- a/grafana-operator/base/instance/session-secret.yaml
+++ b/grafana-operator/base/instance/session-secret.yaml
@@ -3,5 +3,5 @@ data:
   session_secret: Y2hhbmdlIG1lCg==
 kind: Secret
 metadata:
-  name: grafana-k8s-proxy
+  name: grafana-proxy
 type: Opaque

--- a/grafana-operator/base/operator/subscription.yaml
+++ b/grafana-operator/base/operator/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: grafana
 spec:
-  channel: v4
+  channel: v5
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators

--- a/grafana-operator/overlays/user-app-example/kustomization.yaml
+++ b/grafana-operator/overlays/user-app-example/kustomization.yaml
@@ -4,24 +4,28 @@ kind: Kustomization
 
 namespace: user-grafana
 
-commonAnnotations:
-  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
 resources:
   - ../user-app
   - namespace.yaml
   - operator-group.yaml
 
 patches:
-  - path: patch-grafana-sar.yaml
-    target:
-      group: integreatly.org
-      kind: Grafana
-      name: grafana
-      version: v1alpha1
-  - path: patch-cluster-monitoring-view.yaml
-    target:
-      group: rbac.authorization.k8s.io
-      kind: ClusterRoleBinding
-      name: cluster-monitoring-view
-      version: v1
+- patch: |-
+    - op: add
+      path: /subjects/0/namespace
+      value: user-grafana
+    - op: replace
+      path: /metadata/name
+      value: cluster-monitoring-view-user-grafana
+  target:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRoleBinding
+    name: cluster-monitoring-view
+- patch: |-
+    - op: add
+      path: /subjects/0/namespace
+      value: user-grafana
+  target:
+    group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: grafana-proxy

--- a/grafana-operator/overlays/user-app-example/patch-cluster-monitoring-view.yaml
+++ b/grafana-operator/overlays/user-app-example/patch-cluster-monitoring-view.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /subjects/0/namespace
-  value: user-grafana
-- op: replace
-  path: /metadata/name
-  value: cluster-monitoring-view-user-grafana

--- a/grafana-operator/overlays/user-app-example/patch-grafana-sar.yaml
+++ b/grafana-operator/overlays/user-app-example/patch-grafana-sar.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/containers/0/env/0/value
-  value: '-openshift-sar={"namespace":"user-grafana","resource":"routes","name":"grafana-route","verb":"get"}'

--- a/grafana-operator/overlays/user-app/cluster-monitor-view-rb.yaml
+++ b/grafana-operator/overlays/user-app/cluster-monitor-view-rb.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: cluster-monitoring-view
 subjects:
   - kind: ServiceAccount
-    name: grafana-serviceaccount
+    name: grafana-sa
     namespace: patch-me

--- a/grafana-operator/overlays/user-app/grafana-auth-secret.yaml
+++ b/grafana-operator/overlays/user-app/grafana-auth-secret.yaml
@@ -4,4 +4,5 @@ metadata:
   name: grafana-auth-secret
   annotations:
     kubernetes.io/service-account.name: grafana-sa
+    argocd.argoproj.io/sync-wave: "2"
 type: kubernetes.io/service-account-token

--- a/grafana-operator/overlays/user-app/grafana-auth-secret.yaml
+++ b/grafana-operator/overlays/user-app/grafana-auth-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: grafana-auth-secret
   annotations:
-    kubernetes.io/service-account.name: grafana-serviceaccount
+    kubernetes.io/service-account.name: grafana-sa
 type: kubernetes.io/service-account-token

--- a/grafana-operator/overlays/user-app/grafana-ds.yaml
+++ b/grafana-operator/overlays/user-app/grafana-ds.yaml
@@ -1,5 +1,5 @@
 apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaDataSource
+kind: GrafanaDatasource
 metadata:
   name: prometheus
 spec:

--- a/grafana-operator/overlays/user-app/grafana-ds.yaml
+++ b/grafana-operator/overlays/user-app/grafana-ds.yaml
@@ -19,4 +19,3 @@ spec:
   instanceSelector:
     matchLabels:
       instance: "grafana"
-  name: prometheus.yaml

--- a/grafana-operator/overlays/user-app/grafana-ds.yaml
+++ b/grafana-operator/overlays/user-app/grafana-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: integreatly.org/v1beta1
 kind: GrafanaDataSource
 metadata:
   name: prometheus

--- a/grafana-operator/overlays/user-app/grafana-ds.yaml
+++ b/grafana-operator/overlays/user-app/grafana-ds.yaml
@@ -1,6 +1,9 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
   name: prometheus
 spec:
   datasource:

--- a/grafana-operator/overlays/user-app/grafana-ds.yaml
+++ b/grafana-operator/overlays/user-app/grafana-ds.yaml
@@ -16,4 +16,7 @@ spec:
         httpHeaderValue1: 'Bearer ${GRAFANA_TOKEN}'
       type: prometheus
       url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
+  instanceSelector:
+    matchLabels:
+      instance: "grafana"
   name: prometheus.yaml

--- a/grafana-operator/overlays/user-app/grafana-ds.yaml
+++ b/grafana-operator/overlays/user-app/grafana-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1beta1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDataSource
 metadata:
   name: prometheus

--- a/grafana-operator/overlays/user-app/grafana-ds.yaml
+++ b/grafana-operator/overlays/user-app/grafana-ds.yaml
@@ -3,19 +3,19 @@ kind: GrafanaDatasource
 metadata:
   name: prometheus
 spec:
-  datasources:
-    - access: proxy
-      editable: true
-      isDefault: true
-      jsonData:
-        httpHeaderName1: 'Authorization'
-        timeInterval: 5s
-        tlsSkipVerify: true
-      name: Prometheus
-      secureJsonData:
-        httpHeaderValue1: 'Bearer ${GRAFANA_TOKEN}'
-      type: prometheus
-      url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
+  datasource:
+    access: proxy
+    editable: true
+    isDefault: true
+    jsonData:
+      httpHeaderName1: 'Authorization'
+      timeInterval: 5s
+      tlsSkipVerify: true
+    name: Prometheus
+    secureJsonData:
+      httpHeaderValue1: 'Bearer ${GRAFANA_TOKEN}'
+    type: prometheus
+    url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
   instanceSelector:
     matchLabels:
       instance: "grafana"

--- a/grafana-operator/overlays/user-app/kustomization.yaml
+++ b/grafana-operator/overlays/user-app/kustomization.yaml
@@ -15,9 +15,8 @@ resources:
 patches:
   - patch: |-
       - op: add
-        path: /spec/deployment
+        path: /spec/deployment/spec/template/spec/containers/0/env
         value:
-          env:
           - name: GRAFANA_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Grafana has dropped support for v4 and now the v4 channel installs v5 grafana. The CRDs between v4 and v5 have changed significantly, this PR will update grafana to work as expected on OpenShift with the V5 version.