### PR TITLE
Add loki operator manifests

### DIFF
--- a/loki-operator/operator/base/kustomization.yaml
+++ b/loki-operator/operator/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-operators-redhat
+
+resources:
+  - namespace.yaml
+  - subscription.yaml

--- a/loki-operator/operator/base/namespace.yaml
+++ b/loki-operator/operator/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/loki-operator/operator/base/subscription.yaml
+++ b/loki-operator/operator/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: loki-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: "patch-me-in-overlay"
+  installPlanApproval: Automatic
+  name: loki-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/loki-operator/operator/overlays/stable-5.8/kustomization.yaml
+++ b/loki-operator/operator/overlays/stable-5.8/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: loki-operator
+      namespace: openshift-operators-redhat
+      version: v1alpha1

--- a/loki-operator/operator/overlays/stable-5.8/patch-channel.yaml
+++ b/loki-operator/operator/overlays/stable-5.8/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-5.8'

--- a/loki-operator/operator/overlays/stable-5.9/kustomization.yaml
+++ b/loki-operator/operator/overlays/stable-5.9/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: loki-operator
+      namespace: openshift-operators-redhat
+      version: v1alpha1

--- a/loki-operator/operator/overlays/stable-5.9/patch-channel.yaml
+++ b/loki-operator/operator/overlays/stable-5.9/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-5.9'

--- a/loki-operator/operator/overlays/stable/kustomization.yaml
+++ b/loki-operator/operator/overlays/stable/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: loki-operator
+      namespace: openshift-operators-redhat
+      version: v1alpha1

--- a/loki-operator/operator/overlays/stable/patch-channel.yaml
+++ b/loki-operator/operator/overlays/stable/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable'


### PR DESCRIPTION
This pull requests adds manifests to deploy the loki operator

fixes #308 

Based on latest official docs: https://docs.openshift.com/container-platform/4.15/observability/logging/log_storage/installing-log-storage.html#logging-loki-cli-install_installing-log-storage