### PR TITLE
Adding LVM-Storage channel 4.16 support

### DIFF
--- a/lvm-storage/operator/overlays/stable-4.16/kustomization.yaml
+++ b/lvm-storage/operator/overlays/stable-4.16/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: lvms-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
+++ b/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/channel
+  value: 4.16-stable
+
+- op: add
+  path: /spec/startingCSV
+  value: lvms-operator.v4.16.0

--- a/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
+++ b/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
@@ -2,6 +2,6 @@
   path: /spec/channel
   value: stable-4.16
 
-- op: add
-  path: /spec/startingCSV
-  value: lvms-operator.v4.16.0
+# - op: add
+#   path: /spec/startingCSV
+#   value: lvms-operator.v4.16.0

--- a/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
+++ b/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/channel
-  value: 4.16-stable
+  value: stable-4.16
 
 - op: add
   path: /spec/startingCSV

--- a/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
+++ b/lvm-storage/operator/overlays/stable-4.16/patch-channel.yaml
@@ -1,7 +1,3 @@
 - op: replace
   path: /spec/channel
   value: stable-4.16
-
-# - op: add
-#   path: /spec/startingCSV
-#   value: lvms-operator.v4.16.0


### PR DESCRIPTION
Adding kustomization overlay for LVM Storage Operator `channel: stable-4.16` . Modified subscription patch operation, to match the new `spec.channel` naming convention as well. 