### PR TITLE
Change env value from boolean to string

### DIFF
--- a/openshift-gitops-operator/operator/components/disable-default-instance/patch-subscription.yaml
+++ b/openshift-gitops-operator/operator/components/disable-default-instance/patch-subscription.yaml
@@ -6,4 +6,4 @@ spec:
   config:
     env:
       - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
-        value: true
+        value: "true"


### PR DESCRIPTION
This is because of the following error while applying an overlay with `disable-default-instance` component:

`The Subscription "openshift-gitops-operator" is invalid: spec.config.env[0].value: Invalid value: "boolean": spec.config.env[0].value in body must be of type string: "boolean"`
