### PR TITLE
Remove component from operator base kustomization.yaml

### DIFF
--- a/openshift-gitops-operator/operator/base/kustomization.yaml
+++ b/openshift-gitops-operator/operator/base/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
   - subscription.yaml
 
 components:
-  - ../components/enable-console-plugin
+

--- a/openshift-gitops-operator/operator/base/kustomization.yaml
+++ b/openshift-gitops-operator/operator/base/kustomization.yaml
@@ -3,6 +3,3 @@ kind: Kustomization
 
 resources:
   - subscription.yaml
-
-components:
-


### PR DESCRIPTION
In general, components should rather appear in overlays, thus the change.

In this particular case there is also another issue, because enable-console-plugin component depends on GitOPS operator (e.g. openshift-gitops namespace must exist), which of course is not yet available, so kustomize will always throw errors whenever this component is used.