### PR TITLE
Delete gitops-admins-group.yaml from default overlay directory.

### DIFF
--- a/openshift-gitops-operator/instance/overlays/default/gitops-admins-group.yaml
+++ b/openshift-gitops-operator/instance/overlays/default/gitops-admins-group.yaml
@@ -1,5 +1,0 @@
-kind: Group
-apiVersion: user.openshift.io/v1
-metadata:
-  name: gitops-admins
-users: []  # add users here


### PR DESCRIPTION
There is no reference to this file from within kustomization.yaml in its directory. Also, this file is part of `../../components/gitops-admins` component, where is the proper place for it.