### PR TITLE
Add Apicurio Registry and enhance Crunchy Postgres

### DIFF
--- a/.wordlist-md
+++ b/.wordlist-md
@@ -9,9 +9,11 @@ Alertmanager
 AmazonS
 AmazonSageMakerFullAccess
 Ansible
+Apicurio
 ArgoCD
 ArgoCD's
 Authorino
+AutoCreateUserSchema
 Bitnami
 CICD
 CRD
@@ -95,6 +97,7 @@ SDKs
 SNO
 SSO
 Sagemaker
+Schemas
 SecretManager
 SecureCluster
 ServiceMesh
@@ -226,6 +229,7 @@ operatorGroups
 patchesJson
 performant
 postgres
+postgresql
 pre
 prem
 prometheus
@@ -241,6 +245,7 @@ runtime
 sagemaker
 sandboxed
 scalable
+schemas
 secretGenerator
 seldon
 selectable

--- a/apicurio-registry-operator/.editorconfig
+++ b/apicurio-registry-operator/.editorconfig
@@ -1,0 +1,8 @@
+# Apicurio Registry Operator EditorConfig File
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/apicurio-registry-operator/README.md
+++ b/apicurio-registry-operator/README.md
@@ -1,0 +1,44 @@
+# Apicurio Registry Operator
+
+Install Apicurio Registry Operator.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the intended version of Apicurio Registry.
+
+the current *overlays* available are for the following channels:
+
+* [2.x](operator/overlays/2.x)
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install Apicurio Registry Operator based on the overlay of your choice by running from the root (`gitops-catalog`) directory.
+
+```
+oc apply -k apicurio-registry-operator/operator/overlays/<channel>
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/apicurio-registry-operator/operator/overlays/<channel>
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/redhat-cop/gitops-catalog/apicurio-registry-operator/operator/overlays/<channel>?ref=main
+```
+
+## Deploying Apicurio Registry
+
+If you would like to deploy Apicurio Registry, you can try one of the samples in the `instance/overlays` directory.
+
+## All-in-One
+
+If you would like to deploy the operator *and* Apicurio Registry and a backing store all in one line, use one of the `aggregate` directories, for example:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/apicurio-registry-operator/aggregate/apicurio-registry-sql?ref=main
+```

--- a/apicurio-registry-operator/aggregate/apicurio-registry-sql/kustomization.yaml
+++ b/apicurio-registry-operator/aggregate/apicurio-registry-sql/kustomization.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../crunchy-postgres-operator/operator/overlays/v5
+  - ../../../crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db
+  - ../../operator/overlays/2.x
+  - ../../instance/overlays/postgresql
+
+components:
+  - ../../../crunchy-postgres-operator/operator/components/separate-namespace
+  - ../../../crunchy-postgres-operator/operator/components/feature-gates
+  - ../../../crunchy-postgres-operator/instance/components/auto-create-user-schema
+
+patches:
+  - target:
+      group: postgres-operator.crunchydata.com
+      version: v1beta1
+      kind: PostgresCluster
+      name: default
+    path: patch-postgres-cluster.yaml
+  - target:
+      group: ''
+      version: v1
+      kind: Secret
+      name: default-pguser-dbuser
+    path: patch-dbuser-credentials.yaml
+
+replacements:
+  - source:
+      group: ''
+      version: v1
+      kind: Secret
+      name: apicurio-registry-db-pguser-apicurio
+      fieldPath: metadata.labels.postgres-operator\.crunchydata\.com/pguser
+    targets:
+      - select:
+          group: registry.apicur.io
+          version: v1
+          kind: ApicurioRegistry
+          name: default
+        fieldPaths:
+          - spec.configuration.sql.dataSource.userName
+  - source:
+      group: ''
+      version: v1
+      kind: Secret
+      name: apicurio-registry-db-pguser-apicurio
+      fieldPath: stringData.password
+    targets:
+      - select:
+          group: registry.apicur.io
+          version: v1
+          kind: ApicurioRegistry
+          name: default
+        fieldPaths:
+          - spec.configuration.sql.dataSource.password

--- a/apicurio-registry-operator/aggregate/apicurio-registry-sql/patch-dbuser-credentials.yaml
+++ b/apicurio-registry-operator/aggregate/apicurio-registry-sql/patch-dbuser-credentials.yaml
@@ -1,0 +1,21 @@
+# Validate expectations before making changes
+- op: test
+  path: /metadata/name
+  value: default-pguser-dbuser
+- op: test
+  path: /metadata/labels/postgres-operator.crunchydata.com~1cluster
+  value: default
+- op: test
+  path: /metadata/labels/postgres-operator.crunchydata.com~1pguser
+  value: dbuser
+
+# Customize for Apicurio Registry
+- op: replace
+  path: /metadata/name
+  value: apicurio-registry-db-pguser-apicurio
+- op: replace
+  path: /metadata/labels/postgres-operator.crunchydata.com~1cluster
+  value: apicurio-registry-db
+- op: replace
+  path: /metadata/labels/postgres-operator.crunchydata.com~1pguser
+  value: apicurio

--- a/apicurio-registry-operator/aggregate/apicurio-registry-sql/patch-postgres-cluster.yaml
+++ b/apicurio-registry-operator/aggregate/apicurio-registry-sql/patch-postgres-cluster.yaml
@@ -1,0 +1,21 @@
+# Validate expectations before making changes
+- op: test
+  path: /metadata/name
+  value: default
+- op: test
+  path: /spec/users/0/name
+  value: dbuser
+- op: test
+  path: /spec/users/0/databases/0
+  value: db
+
+# Update postgrescluster for use by Apicurio Registry
+- op: replace
+  path: /metadata/name
+  value: apicurio-registry-db
+- op: replace
+  path: /spec/users/0/name
+  value: apicurio
+- op: replace
+  path: /spec/users/0/databases/0
+  value: registry

--- a/apicurio-registry-operator/instance/base/apicurio-registry.yaml
+++ b/apicurio-registry-operator/instance/base/apicurio-registry.yaml
@@ -1,0 +1,19 @@
+apiVersion: registry.apicur.io/v1
+kind: ApicurioRegistry
+metadata:
+  name: default
+spec:
+  deployment:
+    host: apicurio-registry
+    managedResources:
+      disableIngress: true
+  configuration:
+    persistence: sql
+    security: { }
+    # Too many bugs with Apicurio Registry handling SSL itself right now, so just disable Ingress and do it manually
+    # See https://issues.redhat.com/browse/IPT-1159
+    # Then the above issue is worked around, the pathing/redirects are then broken, so Apicurio Registry still isn't
+    # usable. When it's all fixed, maybe re-enable the following:
+    # https:
+    #   disableHttp: true
+    #   secretName: apicurio-registry-cert

--- a/apicurio-registry-operator/instance/base/kustomization.yaml
+++ b/apicurio-registry-operator/instance/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - apicurio-registry.yaml

--- a/apicurio-registry-operator/instance/components/https-ingress/ingress.yaml
+++ b/apicurio-registry-operator/instance/components/https-ingress/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: apicurio-registry
+  annotations:
+    route.openshift.io/termination: edge
+spec:
+  ingressClassName: openshift-default
+  tls:
+    - secretName: apicurio-registry-cert
+      hosts:
+        - apicurio-registry.apps.cluster.example.com
+  rules:
+    - host: apicurio-registry.apps.cluster.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: default-service
+                port:
+                  name: http

--- a/apicurio-registry-operator/instance/components/https-ingress/kustomization.yaml
+++ b/apicurio-registry-operator/instance/components/https-ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ingress.yaml

--- a/apicurio-registry-operator/instance/overlays/postgresql-tls-letsencrypt/apicurio-registry-cert.yaml
+++ b/apicurio-registry-operator/instance/overlays/postgresql-tls-letsencrypt/apicurio-registry-cert.yaml
@@ -1,0 +1,24 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: apicurio-registry-cert
+  annotations:
+    acme.cert-manager.io/http01-override-ingress-name: apicurio-registry
+    cert-manager.io/issue-temporary-certificate: 'true'
+spec:
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  secretName: apicurio-registry-cert
+  dnsNames:
+    # These should be replaced in a kustomize overlay, according to intended hostnames
+    - apicurio-registry.apps.cluster.example.com
+  usages:
+    - digital signature
+    - key encipherment
+  secretTemplate:
+    annotations:
+      kubernetes.io/description: >-
+        Secret issued via cert-manager which will be referenced and used by Apicurio Registry for securing
+        HTTPS traffic

--- a/apicurio-registry-operator/instance/overlays/postgresql-tls-letsencrypt/kustomization.yaml
+++ b/apicurio-registry-operator/instance/overlays/postgresql-tls-letsencrypt/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../postgresql
+  - apicurio-registry-cert.yaml
+
+components:
+  - ../../components/https-ingress
+
+replacements:
+  - source:
+      group: registry.apicur.io
+      version: v1
+      kind: ApicurioRegistry
+      name: default
+      fieldPath: spec.deployment.host
+    targets:
+      - select:
+          group: cert-manager.io
+          version: v1
+          kind: Certificate
+          name: apicurio-registry-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          group: networking.k8s.io
+          version: v1
+          kind: Ingress
+          name: apicurio-registry
+        fieldPaths:
+          - spec.tls.0.hosts.0
+          - spec.rules.0.host

--- a/apicurio-registry-operator/instance/overlays/postgresql/kustomization.yaml
+++ b/apicurio-registry-operator/instance/overlays/postgresql/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      group: registry.apicur.io
+      version: v1
+      kind: ApicurioRegistry
+      name: default
+    path: patch-apicurio-registry.yaml

--- a/apicurio-registry-operator/instance/overlays/postgresql/patch-apicurio-registry.yaml
+++ b/apicurio-registry-operator/instance/overlays/postgresql/patch-apicurio-registry.yaml
@@ -1,0 +1,11 @@
+- op: replace
+  path: /spec/configuration/persistence
+  value: sql
+
+- op: add
+  path: /spec/configuration/sql
+  value:
+    dataSource:
+      url: jdbc:postgresql://apicurio-registry-db-primary:5432/registry
+      userName: registry-user
+      password: registry-password

--- a/apicurio-registry-operator/operator/base/kustomization.yaml
+++ b/apicurio-registry-operator/operator/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operator-group.yaml
+  - subscription.yaml

--- a/apicurio-registry-operator/operator/base/namespace.yaml
+++ b/apicurio-registry-operator/operator/base/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apicurio-registry-operator
+  annotations:
+    openshift.io/display-name: Red Hat build of Apicurio Registry Operator
+  labels:
+    openshift.io/cluster-monitoring: 'true'

--- a/apicurio-registry-operator/operator/base/operator-group.yaml
+++ b/apicurio-registry-operator/operator/base/operator-group.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: apicurio-registry-operator
+  namespace: apicurio-registry-operator
+spec:

--- a/apicurio-registry-operator/operator/base/subscription.yaml
+++ b/apicurio-registry-operator/operator/base/subscription.yaml
@@ -1,13 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: crunchy-postgres-operator
-  namespace: openshift-operators
+  name: service-registry-operator
+  namespace: apicurio-registry-operator
 spec:
   channel: patch-me-see-overlays-dir
   installPlanApproval: Automatic
-  name: crunchy-postgres-operator
-  source: certified-operators
+  name: service-registry-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
-  config:
-    env: []

--- a/apicurio-registry-operator/operator/overlays/2.x/kustomization.yaml
+++ b/apicurio-registry-operator/operator/overlays/2.x/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Subscription
+      name: service-registry-operator
+    path: patch-subscription.yaml

--- a/apicurio-registry-operator/operator/overlays/2.x/patch-subscription.yaml
+++ b/apicurio-registry-operator/operator/overlays/2.x/patch-subscription.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 2.x

--- a/crunchy-postgres-operator/.editorconfig
+++ b/crunchy-postgres-operator/.editorconfig
@@ -1,0 +1,8 @@
+# Crunchy Postgres Operator EditorConfig File
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/crunchy-postgres-operator/README.md
+++ b/crunchy-postgres-operator/README.md
@@ -30,3 +30,7 @@ kind: Kustomization
 resources:
   - https://github.com/redhat-cop/gitops-catalog/crunchy-postgres-operator/operator/overlays/<channel>?ref=main
 ```
+
+## Deploying Databases
+
+If you would like to deploy a database, you can try one of the sample databases in the `instance/overlays` directory.

--- a/crunchy-postgres-operator/instance/base/kustomization.yaml
+++ b/crunchy-postgres-operator/instance/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - postgres-cluster.yaml

--- a/crunchy-postgres-operator/instance/base/postgres-cluster.yaml
+++ b/crunchy-postgres-operator/instance/base/postgres-cluster.yaml
@@ -1,0 +1,30 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: default
+  annotations: {}
+spec:
+  postgresVersion: 16
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+      restore:
+        repoName: repo1
+        enabled: false
+  users: []

--- a/crunchy-postgres-operator/instance/components/auto-create-user-schema/README.md
+++ b/crunchy-postgres-operator/instance/components/auto-create-user-schema/README.md
@@ -1,0 +1,11 @@
+# Auto-Create User Schemas
+
+This component will signal the Crunchy Postgres Operator to automatically create a schema for each user it creates.
+
+With Postgres 15, the default permissions of the "public" schema were reduced. Many applications assume that they have
+permissions to create tables, which is no longer the case with the new permissions. Instead, the schema search order
+is changed to "$user","public" -- this means that a schema with the username will be searched before the public schema.
+By asking the operator to auto-create user schemas, applications may again operate without explicitly changing schema.
+
+The "AutoCreateUserSchemas" feature flag must be enabled on the operator for this component to take effect on deployed
+databases.

--- a/crunchy-postgres-operator/instance/components/auto-create-user-schema/README.md
+++ b/crunchy-postgres-operator/instance/components/auto-create-user-schema/README.md
@@ -7,5 +7,5 @@ permissions to create tables, which is no longer the case with the new permissio
 is changed to "$user","public" -- this means that a schema with the username will be searched before the public schema.
 By asking the operator to auto-create user schemas, applications may again operate without explicitly changing schema.
 
-The "AutoCreateUserSchemas" feature flag must be enabled on the operator for this component to take effect on deployed
+The "AutoCreateUserSchema" feature flag must be enabled on the operator for this component to take effect on deployed
 databases.

--- a/crunchy-postgres-operator/instance/components/auto-create-user-schema/kustomization.yaml
+++ b/crunchy-postgres-operator/instance/components/auto-create-user-schema/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      group: postgres-operator.crunchydata.com
+      version: v1beta1
+      kind: PostgresCluster
+      name: default
+    path: patch-auto-create-user-schema-annotation.yaml

--- a/crunchy-postgres-operator/instance/components/auto-create-user-schema/patch-auto-create-user-schema-annotation.yaml
+++ b/crunchy-postgres-operator/instance/components/auto-create-user-schema/patch-auto-create-user-schema-annotation.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/postgres-operator.crunchydata.com~1autoCreateUserSchema
+  value: 'true'

--- a/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/README.md
+++ b/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/README.md
@@ -1,0 +1,4 @@
+# Postgresql Database with Pre-defined User, Password, and Database
+
+This overlay introduces a user with pre-defined password and database. This may be useful when applications or
+operators do not have functionality to load passwords from Secrets and need to have the password set in advance.

--- a/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/default-pguser-dbuser.yaml
+++ b/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/default-pguser-dbuser.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # Secret name takes the form of <PostgresCluster name>-pguser-<username>
+  name: default-pguser-dbuser
+  labels:
+    postgres-operator.crunchydata.com/cluster: default
+    postgres-operator.crunchydata.com/pguser: dbuser
+type: Opaque
+stringData:
+  password: "pre-set-password"
+  # Empty string verifier signals to Crunchy Postgres Operator that the password key is not pre-hashed
+  verifier: ""

--- a/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/kustomization.yaml
+++ b/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - default-pguser-dbuser.yaml
+
+patches:
+  - target:
+      group: postgres-operator.crunchydata.com
+      version: v1beta1
+      kind: PostgresCluster
+      name: default
+    path: patch-add-user-and-database.yaml

--- a/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/patch-add-user-and-database.yaml
+++ b/crunchy-postgres-operator/instance/overlays/predefined-user-pass-and-db/patch-add-user-and-database.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/users/-
+  value:
+    name: dbuser
+    databases:
+      - db

--- a/crunchy-postgres-operator/operator/components/feature-gates/README.md
+++ b/crunchy-postgres-operator/operator/components/feature-gates/README.md
@@ -1,0 +1,21 @@
+# feature-gates
+
+## Purpose
+
+This component is designed facilitate enabling of feature gates with the Crunchy Postgres Operator, such as the
+"AutoCreateUserSchema" feature gate.
+
+## Usage
+
+This component can be added to a base by adding the `components` section to your overlay `kustomization.yaml` file:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/feature-gates
+```

--- a/crunchy-postgres-operator/operator/components/feature-gates/kustomization.yaml
+++ b/crunchy-postgres-operator/operator/components/feature-gates/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: crunchy-postgres-operator
+    path: patch-subscription.yaml

--- a/crunchy-postgres-operator/operator/components/feature-gates/patch-subscription.yaml
+++ b/crunchy-postgres-operator/operator/components/feature-gates/patch-subscription.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/config/env/-
+  value:
+    name: PGO_FEATURE_GATES
+    value: AutoCreateUserSchema=true

--- a/crunchy-postgres-operator/operator/components/separate-namespace/README.md
+++ b/crunchy-postgres-operator/operator/components/separate-namespace/README.md
@@ -1,0 +1,21 @@
+# separate-namespace
+
+## Purpose
+
+This component is designed move installation of the Crunchy Postgres Operator into its own namespace. This facilitates
+better control of upgrade approval for this operator without impacting other operators.
+
+## Usage
+
+This component can be added to a base by adding the `components` section to your overlay `kustomization.yaml` file:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/separate-namespace
+```

--- a/crunchy-postgres-operator/operator/components/separate-namespace/kustomization.yaml
+++ b/crunchy-postgres-operator/operator/components/separate-namespace/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - namespace.yaml
+  - operator-group.yaml
+
+patches:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: crunchy-postgres-operator
+    path: patch-subscription.yaml

--- a/crunchy-postgres-operator/operator/components/separate-namespace/namespace.yaml
+++ b/crunchy-postgres-operator/operator/components/separate-namespace/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crunchy-postgres-operator
+  annotations:
+    openshift.io/display-name: Crunchy Postgres Operator
+    openshift.io/description: >-
+      A project to host the Crunchy Postgres Operator so that it may be managed and upgraded separately from other
+      operators.
+  labels:
+    openshift.io/cluster-monitoring: 'true'

--- a/crunchy-postgres-operator/operator/components/separate-namespace/operator-group.yaml
+++ b/crunchy-postgres-operator/operator/components/separate-namespace/operator-group.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: crnucby-postgres-operator
+  namespace: crunchy-postgres-operator
+spec:

--- a/crunchy-postgres-operator/operator/components/separate-namespace/patch-subscription.yaml
+++ b/crunchy-postgres-operator/operator/components/separate-namespace/patch-subscription.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: crunchy-postgres-operator


### PR DESCRIPTION
Aggregate Apicurio Registry uses Postgres database from Crunchy Postgres. To make Crunchy-deployed databases work for Apicurio Registry, a feature gate needs to be enabled.