### PR TITLE
Fix for Node Feature Discovery Operator in OCP 4.17

### DIFF
--- a/nfd/instance/base/node-feature-discovery.yaml
+++ b/nfd/instance/base/node-feature-discovery.yaml
@@ -15,7 +15,7 @@ spec:
   operand:
     # bug: an image has to be defined otherwise the deployment fails
     # bug: this behavior recently changed
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery:latest
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:latest
     servicePort: 12000
   workerConfig:
     configData: |


### PR DESCRIPTION
GitOps projects that use the nfd operator have been failing in OpenShift 4.17, it looks like the base image has been changed - we verified this by manually installing the operator and observing the new image name.

Update base image in node-feature-discovery.yaml fixes the issue.

We've tested this on an OpenShift 4.17 and 4.15 cluster, and NFD is now working great. More details in one of the downstream projects at: https://github.com/redhat-ai-services/ai-accelerator/pull/80