### PR TITLE
Use Stable channel instead of Alpha one with Service interconnect Operator

### DIFF
--- a/service-interconnect-operator/README.md
+++ b/service-interconnect-operator/README.md
@@ -6,7 +6,7 @@ Do not use the `base` directory directly, as you will need to patch the `channel
 
 The current *overlays* available are for the following channels:
 
-* [alpha](operator/overlays/alpha)
+* [stable](operator/overlays/stable)
 
 ## Usage
 

--- a/service-interconnect-operator/operator/overlays/stable/kustomization.yaml
+++ b/service-interconnect-operator/operator/overlays/stable/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
   - patch: |-
       - op: replace
         path: /spec/channel
-        value: 'alpha'
+        value: 'stable'
     target:
       kind: Subscription
       name: skupper-operator


### PR DESCRIPTION
Now Service interconnect Operator is available in stable channel.