### PR TITLE
updated the ConsolePlugin for 4.18

### DIFF
--- a/openshift-data-foundation-operator/operator/base/openshift-data-foundation-console-plugin.yaml
+++ b/openshift-data-foundation-operator/operator/base/openshift-data-foundation-console-plugin.yaml
@@ -1,11 +1,12 @@
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: odf-console
 spec:
   displayName: ODF Plugin
-  service:
-    basePath: /
-    name: odf-console-service
-    namespace: openshift-storage
-    port: 9001
+  backend:
+    service:
+      basePath: /
+      name: odf-console-service
+      namespace: openshift-storage
+      port: 9001


### PR DESCRIPTION
The consolePlugin API has changed which means we need to update it for it to work with the newer versions.

The API has changed from **v1alpha1** to **v1**

Ref: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/console_apis/consoleplugin-console-openshift-io-v1

The **service** field now expects to be under **backend**

Ref: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/console_apis/consoleplugin-console-openshift-io-v1#spec-5