### PR TITLE
Add required type to ODF ConsolePlugin backend

### DIFF
--- a/openshift-data-foundation-operator/operator/base/openshift-data-foundation-console-plugin.yaml
+++ b/openshift-data-foundation-operator/operator/base/openshift-data-foundation-console-plugin.yaml
@@ -10,3 +10,4 @@ spec:
       name: odf-console-service
       namespace: openshift-storage
       port: 9001
+    type: Service


### PR DESCRIPTION
Type is required as per https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/console_apis/consoleplugin-console-openshift-io-v1#spec-backend