### PR TITLE
Add AAP stable-2.6 and stable-2.6-cluster-scoped overlays

### DIFF
--- a/ansible-automation-platform/operator/overlays/stable-2.6-cluster-scoped/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.6-cluster-scoped/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ansible-automation-platform
+
+resources:
+  - ../../base
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/targetNamespaces
+        value: []
+    target:
+      kind: OperatorGroup
+      name: ansible-automation-platform-operator
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: ansible-automation-platform
+      namespace: ansible-automation-platform
+      version: v1alpha1

--- a/ansible-automation-platform/operator/overlays/stable-2.6-cluster-scoped/patch-channel.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.6-cluster-scoped/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-2.6-cluster-scoped'

--- a/ansible-automation-platform/operator/overlays/stable-2.6/kustomization.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.6/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ansible-automation-platform
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: ansible-automation-platform
+      namespace: ansible-automation-platform
+      version: v1alpha1

--- a/ansible-automation-platform/operator/overlays/stable-2.6/patch-channel.yaml
+++ b/ansible-automation-platform/operator/overlays/stable-2.6/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable-2.6'


### PR DESCRIPTION
This change adds a `stable-2.6` and `stable-2.6-cluster-scoped` overlay for `ansible-automation-platform`.

I did not want to change the instance as it already seems out of date.