### PR TITLE
fix: allow kube-apiserver to reach DevSpaces webhook (fixes #419)

### DIFF
--- a/openshift-dev-spaces/instance/base/allow-webhook-from-apiserver.yaml
+++ b/openshift-dev-spaces/instance/base/allow-webhook-from-apiserver.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-from-apiserver
+spec:
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: 9443
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/openshift-dev-spaces/instance/base/kustomization.yaml
+++ b/openshift-dev-spaces/instance/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - checluster.yaml
   - namespace.yaml
   - network-policy.yaml
+  - allow-webhook-from-apiserver.yaml


### PR DESCRIPTION
Fixes #419

## Problem

When applying the `aggregate/overlays/default` overlay, syncing the `CheCluster` resource fails with a webhook timeout:

```
Internal error occurred: failed calling webhook "mchecluster.kb.io": failed to call webhook:
Post "https://devspaces-operator-service.openshift-devspaces.svc:443/mutate-org-eclipse-che-v2-checluster?timeout=10s": context deadline exceeded
```

The existing `instance/base/network-policy.yaml` restricts ingress to the `openshift-devspaces` namespace to only accept traffic from pods within that same namespace. The kube-apiserver runs with host networking on control plane nodes and is not part of any Kubernetes namespace, so its calls to the mutating webhook server (port 9443) are blocked by this policy.

## Fix

Add a second `NetworkPolicy` (`allow-webhook-from-apiserver`) that explicitly allows ingress on port 9443 without a `from` selector. In Kubernetes, an ingress rule with `ports` but no `from` clause permits traffic from any source, including the kube-apiserver on host network.

This keeps the existing broad ingress restriction in place while carving out a narrow exception for the webhook port only.